### PR TITLE
Propose to labeling Mindustry Tool as Mod as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ## 📖 About
 
-**Mindustry Tool** is a comprehensive mod that integrates with [mindustry-tool.com](https://mindustry-tool.com), transforming your Mindustry experience. Browse thousands of curated **maps** and **schematics**, host multiplayer servers without port forwarding, and connect with a global community of players.
+**Mindustry Tool** is a comprehensive Mod as a service that integrates with [mindustry-tool.com](https://mindustry-tool.com), transforming your Mindustry experience. Browse thousands of curated **maps** and **schematics**, host multiplayer servers without port forwarding, and connect with a global community of players.
 
 <p align="center">
   <img src="https://img.shields.io/badge/🔒_Security-Verified-success?style=flat-square" alt="Security Verified">

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ## 📖 About
 
-**Mindustry Tool** is a comprehensive Mod as a service that integrates with [mindustry-tool.com](https://mindustry-tool.com), transforming your Mindustry experience. Browse thousands of curated **maps** and **schematics**, host multiplayer servers without port forwarding, and connect with a global community of players.
+**Mindustry Tool** is a comprehensive Mod as a service (MaaS) that integrates with [mindustry-tool.com](https://mindustry-tool.com), transforming your Mindustry experience. Browse thousands of curated **maps** and **schematics**, host multiplayer servers without port forwarding, and connect with a global community of players.
 
 <p align="center">
   <img src="https://img.shields.io/badge/🔒_Security-Verified-success?style=flat-square" alt="Security Verified">


### PR DESCRIPTION
# Overview

In structural, Mindustry Tool is the first Mod as a Service (MaaS) because the mod relies to integration with mindustry-tool.com API. All the services must be connected on backend server which all request from client must relies to the backend server. That's the principle of Software as a Service (SaaS)

# Why?

Mindustry Tool is not longer as ordinary mod anymore, it evolves as service that lock-in on centralized server.

If you don't like it, you can send the comments and I will read it sometimes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tài liệu
* Cập nhật thông tin mô tả về Mindustry Tool để phản ánh chính xác về dịch vụ Mod as a Service (MaaS) được cung cấp.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->