### PR TITLE
fix(chat): automatically show chat fragment when receiving messages

### DIFF
--- a/src/mindustrytool/features/chat/ChatFeature.java
+++ b/src/mindustrytool/features/chat/ChatFeature.java
@@ -2,6 +2,7 @@ package mindustrytool.features.chat;
 
 import mindustry.Vars;
 import mindustry.gen.Iconc;
+import mindustry.ui.fragments.ChatFragment;
 import mindustrytool.features.Feature;
 import mindustrytool.features.FeatureMetadata;
 import mindustrytool.features.chat.dto.ChatMessage;
@@ -26,6 +27,10 @@ public class ChatFeature implements Feature {
 
         ChatService.getInstance().setListener(messages -> {
             if (Vars.ui.chatfrag != null) {
+                if (!Vars.ui.chatfrag.shown()) {
+                    Vars.ui.chatfrag.toggle();
+                }
+
                 for (ChatMessage message : messages) {
                     UserService.findUserById(message.createdBy, (user) -> {
                         String content = "[cyan][Global][] " + user.name() + "[] " + message.content;


### PR DESCRIPTION
Ensure the chat fragment is visible when new messages arrive by toggling it if hidden. This prevents missing messages when the chat UI is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Cập nhật Phát hành

* **Sửa Lỗi**
  * Cải thiện hiển thị giao diện trò chuyện bằng cách đảm bảo cửa sổ chat luôn hiển thị khi có tin nhắn đến.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->