### PR TITLE
feat(playerconnect): add mod version to room stats

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.8.3-v8
+version: v4.8.4-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/playerconnect/Packets.java
+++ b/src/mindustrytool/features/playerconnect/Packets.java
@@ -78,6 +78,7 @@ public class Packets {
         public Seq<String> mods = new Seq<>();
         public String locale;
         public String version;
+        public String modVersion;
         public long createdAt;
 
         public RoomStats() {

--- a/src/mindustrytool/features/playerconnect/PlayerConnect.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnect.java
@@ -21,6 +21,7 @@ import mindustry.game.EventType.PlayerLeave;
 import mindustry.game.EventType.WorldLoadEndEvent;
 import mindustry.gen.Groups;
 import mindustry.gen.Player;
+import mindustrytool.Main;
 import mindustrytool.features.playerconnect.Packets.RoomPlayer;
 
 public class PlayerConnect {
@@ -166,7 +167,6 @@ public class PlayerConnect {
         Vars.logic.reset();
         Vars.net.reset();
 
-
         Log.info("Begin connect: " + link);
         Vars.netClient.beginConnecting();
         Vars.net.connect(link.host, link.port, () -> {
@@ -257,6 +257,8 @@ public class PlayerConnect {
             stats.version = Version.combined();
             stats.players = players;
             stats.createdAt = new Date().getTime();
+            var mod = Vars.mods.getMod(Main.class);
+            stats.modVersion = mod.meta.version;
         } catch (Throwable err) {
             Log.err(err);
         }


### PR DESCRIPTION
Track the mod version in room statistics to help with debugging and compatibility checks. The version is retrieved from the mod's metadata and included in the room stats packet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Room statistics now include mod version information for improved connectivity tracking.

* **Chores**
  * Version bumped to v4.8.4-v8.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->