### PR TITLE
fix(auth): remove redundant logout calls during error handling

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.8.5-v8
+version: v4.8.6-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/auth/AuthFeature.java
+++ b/src/mindustrytool/features/auth/AuthFeature.java
@@ -50,7 +50,6 @@ public class AuthFeature implements Feature {
                 .thenCompose((_void) -> AuthService.getInstance().fetchUserSession())
                 .thenRun(() -> Core.app.post(this::updateAuthWindow))
                 .exceptionally((error) -> {
-                    AuthService.getInstance().logout();
                     Core.app.post(this::updateAuthWindow);
 
                     return null;

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -275,15 +275,13 @@ public class AuthService {
                             refreshFuture.complete(null);
                         } else {
 
-                            logout();
-
                             Log.err("Failed to refresh token: response does not contain accessToken or refreshToken");
                             refreshFuture.completeExceptionally(new RuntimeException("Invalid refresh response"));
                         }
                     } catch (Exception e) {
 
                         if (e instanceof HttpStatusException httpError) {
-                            if (httpError.status.code == 401 || httpError.status.code == 400) {
+                            if (httpError.status.code == 401) {
                                 logout();
                             }
                         }


### PR DESCRIPTION
Clean up error handling logic by removing unnecessary logout calls when token refresh fails. Only logout on 401 status code to maintain proper session state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration to prevent automatic logouts when encountering temporary failures, allowing users to maintain their sessions
  * Refined authentication error handling to reduce unnecessary logouts, now limiting automatic logout exclusively to critical authentication failures

* **Chores**
  * Updated application version to v4.8.6-v8

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->