### PR TITLE
refactor(cache): replace caffeine cache with simple maps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,7 @@ dependencies{
       
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
-    implementation 'com.github.ben-manes.caffeine:caffeine:2.9.2'
-
+    
     annotationProcessor 'org.projectlombok:lombok:1.18.32'
     annotationProcessor "com.github.Anuken:jabel:$jabelVersion"
 }

--- a/src/mindustrytool/services/PlayerConnectService.java
+++ b/src/mindustrytool/services/PlayerConnectService.java
@@ -1,9 +1,6 @@
 package mindustrytool.services;
 
-import java.time.Duration;
-
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.ConcurrentHashMap;
 
 import arc.Core;
 import arc.func.Cons;
@@ -16,9 +13,7 @@ import mindustrytool.features.playerconnect.PlayerConnectProvider;
 
 public class PlayerConnectService {
 
-    private static final Cache<String, PlayerConnectRoom> roomCache = Caffeine.newBuilder()
-            .expireAfterWrite(Duration.ofMinutes(10))
-            .build();
+    private static final ConcurrentHashMap<String, PlayerConnectRoom> roomCache = new ConcurrentHashMap<>();
 
     @SuppressWarnings("unchecked")
     public void findPlayerConnectRooms(String q, Cons<Seq<PlayerConnectRoom>> cons) {
@@ -59,7 +54,7 @@ public class PlayerConnectService {
     }
 
     public void getRoomWithCache(String link, Cons<PlayerConnectRoom> cons) {
-        var cached = roomCache.getIfPresent(link);
+        var cached = roomCache.get(link);
 
         if (cached != null) {
             Core.app.post(() -> cons.get(cached));
@@ -79,6 +74,6 @@ public class PlayerConnectService {
     }
 
     public void invalidateRoom(String link) {
-        roomCache.invalidate(link);
+        roomCache.remove(link);
     }
 }

--- a/src/mindustrytool/services/UserService.java
+++ b/src/mindustrytool/services/UserService.java
@@ -1,10 +1,5 @@
 package mindustrytool.services;
 
-import java.time.Duration;
-
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 import arc.Core;
 import arc.func.Cons;
 import arc.struct.ObjectMap;
@@ -16,15 +11,12 @@ import mindustrytool.dto.UserData;
 
 public class UserService {
 
-    private static final Cache<String, UserData> cache = Caffeine.newBuilder()
-            .expireAfterWrite(Duration.ofMinutes(10))
-            .build();
-
+    private static final ObjectMap<String, UserData> cache = new ObjectMap<String, UserData>();
     private static final ObjectMap<String, Seq<Cons<UserData>>> listeners = new ObjectMap<>();
 
     public static void findUserById(String id, Cons<UserData> c) {
 
-        UserData cached = cache.getIfPresent(id);
+        UserData cached = cache.get(id);
 
         if (cached != null) {
             c.get(cached);


### PR DESCRIPTION
The caffeine cache dependency was removed and replaced with ObjectMap and ConcurrentHashMap implementations. This simplifies the caching mechanism and removes an external dependency while maintaining the same basic functionality.