### PR TITLE
fix: delay load fragment display after mod import

### DIFF
--- a/src/mindustrytool/Main.java
+++ b/src/mindustrytool/Main.java
@@ -7,6 +7,7 @@ import arc.scene.ui.layout.Table;
 import arc.struct.Seq;
 import arc.util.Http;
 import arc.util.Log;
+import arc.util.Timer;
 import arc.util.serialization.Jval;
 import mindustry.Vars;
 import mindustry.editor.MapResizeDialog;
@@ -181,9 +182,9 @@ public class Main extends Mod {
             dialog.buttons.button("Cancel", dialog::hide).size(100f, 50f);
             dialog.buttons.button("Update", () -> {
                 dialog.hide();
-                Vars.ui.mods.show();
                 Vars.ui.mods.githubImportMod(Config.REPO_URL, true, null);
-                Vars.ui.loadfrag.toFront();
+                Vars.ui.mods.show();
+                Timer.schedule(() -> Vars.ui.loadfrag.toFront(), 0.5f);
             }).size(100f, 50f);
 
             dialog.show();


### PR DESCRIPTION
The load fragment was being brought to front immediately after initiating the mod import, which could cause it to be hidden behind other UI elements. Scheduling the toFront() call with a 0.5 second delay ensures the load fragment is properly displayed during the import process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Update button now imports mods from GitHub repository with optimized loading sequence

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->