### PR TITLE
fix: move UI updates to main thread in reactive state management

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.19.0-v8
+version: v4.19.1-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/services/ReactiveStore.java
+++ b/src/mindustrytool/services/ReactiveStore.java
@@ -69,11 +69,11 @@ public final class ReactiveStore<T> {
 
         inFlight = fetcher.get()
                 .thenApply(result -> {
-                    Core.app.post(() -> updateValue(result));
+                    updateValue(result);
                     return result;
                 })
                 .exceptionally(err -> {
-                    Core.app.post(() -> fail(err));
+                    fail(err);
                     throw new CompletionException(err);
                 });
 
@@ -81,16 +81,14 @@ public final class ReactiveStore<T> {
     }
 
     public void setValue(T newValue) {
-        Core.app.post(() -> updateValue(newValue));
+        updateValue(newValue);
     }
 
     public void clear() {
-        Core.app.post(() -> {
-            value = null;
-            state = LoadState.IDLE;
-            lastError = null;
-            notifyListeners();
-        });
+        value = null;
+        state = LoadState.IDLE;
+        lastError = null;
+        notifyListeners();
     }
 
     private void updateValue(T newValue) {
@@ -114,8 +112,10 @@ public final class ReactiveStore<T> {
     }
 
     private void notifyListeners() {
-        for (Listener<T> l : listeners) {
-            l.onUpdate(value, state, lastError);
-        }
+        Core.app.post(() -> {
+            for (Listener<T> l : listeners) {
+                l.onUpdate(value, state, lastError);
+            }
+        });
     }
 }

--- a/src/mindustrytool/services/State.java
+++ b/src/mindustrytool/services/State.java
@@ -34,7 +34,7 @@ public final class State<T> {
         T old = value;
         value = newValue;
 
-        Core.app.post(() -> notifyListeners(newValue, old));
+        notifyListeners(newValue, old);
     }
 
     public void subscribe(Listener<T> listener) {
@@ -47,8 +47,10 @@ public final class State<T> {
     }
 
     private void notifyListeners(T newValue, T oldValue) {
-        for (Listener<T> l : listeners) {
-            l.onChanged(newValue, oldValue);
-        }
+        Core.app.post(() -> {
+            for (Listener<T> l : listeners) {
+                l.onChanged(newValue, oldValue);
+            }
+        });
     }
 }


### PR DESCRIPTION
- Ensure State.set() and ReactiveStore operations notify listeners on UI thread
- Prevent concurrent modification issues by centralizing Core.app.post() calls
- Maintain same asynchronous behavior while fixing potential thread safety bugs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Updates**
  * Updated to version 4.19.1

* **Refactor**
  * Internal optimization improvements for state management and reactive store operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->