### PR TITLE
fix(background): reset Draw state before and after rendering

### DIFF
--- a/src/mindustrytool/features/background/BackgroundFeature.java
+++ b/src/mindustrytool/features/background/BackgroundFeature.java
@@ -117,8 +117,10 @@ public class BackgroundFeature implements Feature {
 
         @Override
         public void render() {
+            Draw.reset();
             Draw.rect(region, Core.graphics.getWidth() / 2f, Core.graphics.getHeight() / 2f,
                     Core.graphics.getWidth(), Core.graphics.getHeight());
+            Draw.reset();
         }
 
         @Override


### PR DESCRIPTION
Ensure proper state management by resetting Draw before and after drawing the background rect to prevent rendering issues with subsequent draw calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability for background display elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->