### PR TITLE
perf(pathfinding): cache spawn path lines to reduce per-frame computa…

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.20.2-v8
+version: v4.20.3-v8
 
 minGameVersion: 154
 


### PR DESCRIPTION
…tion

Refactor path drawing to precompute line segments into a cache that updates every second instead of recalculating every frame. This reduces CPU usage during rendering while maintaining visual accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized spawn path visualization rendering for improved performance and smoother display updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->