### PR TITLE
fix(playerconnect): correct mod conflict detection logic

### DIFF
--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -378,3 +378,24 @@ autoplay.task.assist.name=Auto Build
 autoplay.task.assist.none=None
 autoplay.task.mining.name=Auto Mine
 autoplay.task.repair.name=Auto Repair
+
+# Chat Translation
+chat-translation.description=Translates chat messages using AI.
+chat-translation.error.prefix=[red]Translation Error[]: 
+chat-translation.settings.title=Chat Translation Settings
+chat-translation.settings.show-original=Show Original Message
+chat-translation.settings.providers=Providers
+chat-translation.settings.error-prefix=Error: 
+chat-translation.settings.test-button=Test Configuration
+chat-translation.settings.testing=Testing...
+chat-translation.settings.testing-connection=[gray]Testing connection...
+chat-translation.settings.success=[green]Success:[] 
+chat-translation.settings.failed=[red]Failed:[] 
+chat-translation.gemini.no-api-key=[red]No API Key[]
+chat-translation.gemini.parse-error=[red]Parse Error[]
+chat-translation.gemini.api-key-label=Gemini API Key:
+chat-translation.gemini.get-key-info=Get key from Google AI Studio
+chat-translation.gemini.model-label=Model:
+chat-translation.gemini.timeout-label=Timeout
+chat-translation.provider.gemini=Gemini AI
+chat-translation.provider.none=None

--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -399,3 +399,11 @@ chat-translation.gemini.model-label=Model:
 chat-translation.gemini.timeout-label=Timeout
 chat-translation.provider.gemini=Gemini AI
 chat-translation.provider.none=None
+
+# DeepL
+chat-translation.deepl.no-api-key=[red]No API Key[]
+chat-translation.deepl.parse-error=[red]Parse Error[]
+chat-translation.deepl.api-key-label=DeepL API Key:
+chat-translation.deepl.get-key-info=Get key from DeepL
+chat-translation.deepl.timeout-label=Timeout
+chat-translation.provider.deepl=DeepL

--- a/assets/bundles/bundle_vi.properties
+++ b/assets/bundles/bundle_vi.properties
@@ -326,3 +326,24 @@ autoplay.task.assist.name=Tự động xây dựng
 autoplay.task.assist.none=Không
 autoplay.task.mining.name=Tự động khai thác
 autoplay.task.repair.name=Tự động sửa chữa
+
+# Chat Translation
+chat-translation.description=Dịch tin nhắn chat sử dụng AI.
+chat-translation.error.prefix=[red]Lỗi Dịch[]: 
+chat-translation.settings.title=Cài Đặt Dịch Chat
+chat-translation.settings.show-original=Hiện Tin Nhắn Gốc
+chat-translation.settings.providers=Nhà Cung Cấp
+chat-translation.settings.error-prefix=Lỗi: 
+chat-translation.settings.test-button=Kiểm Tra Cấu Hình
+chat-translation.settings.testing=Đang thử...
+chat-translation.settings.testing-connection=[gray]Đang thử kết nối...
+chat-translation.settings.success=[green]Thành công:[] 
+chat-translation.settings.failed=[red]Thất bại:[] 
+chat-translation.gemini.no-api-key=[red]Chưa có API Key[]
+chat-translation.gemini.parse-error=[red]Lỗi Phân Tích[]
+chat-translation.gemini.api-key-label=Gemini API Key:
+chat-translation.gemini.get-key-info=Lấy key từ Google AI Studio
+chat-translation.gemini.model-label=Mô Hình:
+chat-translation.gemini.timeout-label=Thời Gian Chờ
+chat-translation.provider.gemini=Gemini AI
+chat-translation.provider.none=Không

--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.20.4-v8
+version: v4.21.0-v8
 
 minGameVersion: 154
 

--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.20.3-v8
+version: v4.20.4-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/Main.java
+++ b/src/mindustrytool/Main.java
@@ -29,11 +29,12 @@ import mindustrytool.features.display.range.RangeDisplay;
 import mindustrytool.features.display.quickaccess.QuickAccessHud;
 import mindustrytool.features.auth.AuthFeature;
 import mindustrytool.features.settings.FeatureSettingDialog;
-import mindustrytool.features.chat.ChatFeature;
+import mindustrytool.features.chat.global.ChatFeature;
 import mindustrytool.features.godmode.GodModeFeature;
 import mindustrytool.features.autoplay.AutoplayFeature;
 import mindustrytool.features.background.BackgroundFeature;
 import mindustrytool.features.display.wavepreview.WavePreviewFeature;
+import mindustrytool.features.chat.translation.ChatTranslationFeature;
 
 public class Main extends Mod {
     public static Fi imageDir = Vars.dataDirectory.child("mindustry-tool-caches");
@@ -72,6 +73,7 @@ public class Main extends Mod {
                 new QuickAccessHud(), //
                 new AuthFeature(), //
                 new ChatFeature(),
+                new ChatTranslationFeature(),
                 new GodModeFeature(),
                 new AutoplayFeature(),
                 new WavePreviewFeature(),

--- a/src/mindustrytool/dto/UserData.java
+++ b/src/mindustrytool/dto/UserData.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import arc.struct.Seq;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import mindustrytool.features.chat.dto.ChatUser.SimpleRole;
+import mindustrytool.features.chat.global.dto.ChatUser.SimpleRole;
 
 @Data
 @Accessors(chain = true, fluent = true)

--- a/src/mindustrytool/features/chat/global/ChatConfig.java
+++ b/src/mindustrytool/features/chat/global/ChatConfig.java
@@ -1,4 +1,4 @@
-package mindustrytool.features.chat;
+package mindustrytool.features.chat.global;
 
 import java.time.Instant;
 

--- a/src/mindustrytool/features/chat/global/ChatFeature.java
+++ b/src/mindustrytool/features/chat/global/ChatFeature.java
@@ -1,4 +1,4 @@
-package mindustrytool.features.chat;
+package mindustrytool.features.chat.global;
 
 import java.util.Optional;
 

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -1,4 +1,4 @@
-package mindustrytool.features.chat;
+package mindustrytool.features.chat.global;
 
 import arc.Core;
 import arc.graphics.Color;
@@ -40,8 +40,8 @@ import mindustrytool.MdtKeybinds;
 import mindustrytool.features.auth.AuthService;
 import mindustrytool.features.auth.dto.LoginEvent;
 import mindustrytool.features.auth.dto.LogoutEvent;
-import mindustrytool.features.chat.dto.ChatMessage;
-import mindustrytool.features.chat.dto.ChatUser;
+import mindustrytool.features.chat.global.dto.ChatMessage;
+import mindustrytool.features.chat.global.dto.ChatUser;
 import mindustrytool.services.UserService;
 import mindustrytool.ui.NetworkImage;
 import arc.scene.event.InputEvent;
@@ -54,7 +54,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-import mindustrytool.features.chat.dto.ChatUser.SimpleRole;
+import mindustrytool.features.chat.global.dto.ChatUser.SimpleRole;
 import mindustrytool.features.playerconnect.PlayerConnectLink;
 import mindustrytool.features.playerconnect.PlayerConnectRenderer;
 import mindustrytool.services.PlayerConnectService;

--- a/src/mindustrytool/features/chat/global/ChatService.java
+++ b/src/mindustrytool/features/chat/global/ChatService.java
@@ -1,4 +1,4 @@
-package mindustrytool.features.chat;
+package mindustrytool.features.chat.global;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -16,8 +16,8 @@ import mindustrytool.Config;
 import mindustrytool.Utils;
 import mindustrytool.features.auth.AuthHttp;
 import mindustrytool.features.auth.AuthService;
-import mindustrytool.features.chat.dto.ChatMessage;
-import mindustrytool.features.chat.dto.ChatUser;
+import mindustrytool.features.chat.global.dto.ChatMessage;
+import mindustrytool.features.chat.global.dto.ChatUser;
 
 public class ChatService {
     private static ChatService instance;

--- a/src/mindustrytool/features/chat/global/dto/ChatMessage.java
+++ b/src/mindustrytool/features/chat/global/dto/ChatMessage.java
@@ -1,4 +1,4 @@
-package mindustrytool.features.chat.dto;
+package mindustrytool.features.chat.global.dto;
 
 import lombok.Data;
 

--- a/src/mindustrytool/features/chat/global/dto/ChatUser.java
+++ b/src/mindustrytool/features/chat/global/dto/ChatUser.java
@@ -1,4 +1,4 @@
-package mindustrytool.features.chat.dto;
+package mindustrytool.features.chat.global.dto;
 
 import java.util.Optional;
 

--- a/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
@@ -1,0 +1,26 @@
+package mindustrytool.features.chat.translation;
+
+import arc.Core;
+
+public class ChatTranslationConfig {
+    private static final String PREFIX = "mindustry-tool.chat.translation.";
+    public static final String SHOW_ORIGINAL = PREFIX + "show.original";
+    public static final String PROVIDER = PREFIX + "provider";
+    public static final String GEMINI_API_KEY = "mindustry-tool.gemini.api.key";
+
+    public static boolean isShowOriginal() {
+        return Core.settings.getBool(SHOW_ORIGINAL, true);
+    }
+
+    public static void setShowOriginal(boolean showOriginal) {
+        Core.settings.put(SHOW_ORIGINAL, showOriginal);
+    }
+
+    public static String getProviderId() {
+        return Core.settings.getString(PROVIDER, "noop");
+    }
+
+    public static void setProviderId(String id) {
+        Core.settings.put(PROVIDER, id);
+    }
+}

--- a/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
@@ -10,6 +10,9 @@ public class ChatTranslationConfig {
     public static final String GEMINI_MODEL = "mindustry-tool.gemini.model";
     public static final String GEMINI_TIMEOUT = "mindustry-tool.gemini.timeout";
 
+    public static final String DEEPL_API_KEY = "mindustry-tool.deepl.api.key";
+    public static final String DEEPL_TIMEOUT = "mindustry-tool.deepl.timeout";
+
     public static boolean isShowOriginal() {
         return Core.settings.getBool(SHOW_ORIGINAL, true);
     }

--- a/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
@@ -7,6 +7,8 @@ public class ChatTranslationConfig {
     public static final String SHOW_ORIGINAL = PREFIX + "show.original";
     public static final String PROVIDER = PREFIX + "provider";
     public static final String GEMINI_API_KEY = "mindustry-tool.gemini.api.key";
+    public static final String GEMINI_MODEL = "mindustry-tool.gemini.model";
+    public static final String GEMINI_TIMEOUT = "mindustry-tool.gemini.timeout";
 
     public static boolean isShowOriginal() {
         return Core.settings.getBool(SHOW_ORIGINAL, true);

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -80,6 +80,7 @@ public class ChatTranslationFeature implements Feature {
 
         providers.add(NOOP_PROVIDER);
         providers.add(new GeminiTranslationProvider());
+        providers.add(new DeepLTranslationProvider());
 
         providers.each(TranslationProvider::init);
 

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -1,0 +1,194 @@
+package mindustrytool.features.chat.translation;
+
+import arc.Core;
+import arc.func.Cons;
+import arc.func.Prov;
+import arc.graphics.Color;
+import arc.scene.ui.Button;
+import arc.scene.ui.ButtonGroup;
+import arc.scene.ui.Dialog;
+import arc.scene.ui.layout.Table;
+import arc.util.Log;
+import arc.util.Reflect;
+import arc.util.Strings;
+import mindustry.Vars;
+import mindustry.core.NetClient;
+import mindustry.gen.SendChatMessageCallPacket;
+import mindustry.gen.SendMessageCallPacket;
+import mindustry.gen.SendMessageCallPacket2;
+import mindustry.net.Packet;
+import mindustry.ui.Styles;
+import mindustry.ui.dialogs.BaseDialog;
+import mindustry.ui.dialogs.LanguageDialog;
+import mindustrytool.features.Feature;
+import mindustrytool.features.FeatureManager;
+import mindustrytool.features.FeatureMetadata;
+import arc.struct.Seq;
+
+import java.util.Optional;
+
+public class ChatTranslationFeature implements Feature {
+    private final TranslationProvider NOOP_PROVIDER = new NoopTranslationProvider();
+    private final Seq<TranslationProvider> providers = new Seq<>();
+    private TranslationProvider currentProvider = NOOP_PROVIDER;
+    private String lastError = null;
+    private boolean enabled = false;
+
+    @Override
+    public FeatureMetadata getMetadata() {
+        return FeatureMetadata.builder()
+                .name("chat-translation")
+                .description("Translates chat messages using AI.")
+                .icon(mindustry.gen.Icon.chat)
+                .build();
+    }
+
+    @Override
+    public void init() {
+        Seq<Prov<? extends Packet>> packetProvs = Reflect.get(Vars.net, "packetProvs");
+
+        packetProvs.replace(packet -> {
+            if (packet.get() instanceof SendChatMessageCallPacket) {
+                Log.info("Replace SendChatMessageCallPacket");
+                return () -> new SendMessageCallPacket() {
+                    @Override
+                    public void handleClient() {
+                        handleMessage(this.message, translated -> {
+                            NetClient.sendMessage(translated);
+                        });
+                    }
+                };
+            }
+
+            if (packet.get() instanceof SendMessageCallPacket2) {
+                Log.info("Replace SendMessageCallPacket2");
+                return () -> new SendMessageCallPacket2() {
+                    @Override
+                    public void handleClient() {
+                        handleMessage(this.message, translated -> {
+                            NetClient.sendMessage(translated, this.unformatted, this.playersender);
+                        });
+                    }
+                };
+            }
+
+            return packet;
+        });
+
+        providers.add(NOOP_PROVIDER);
+        providers.add(new GeminiTranslationProvider());
+
+        providers.each(TranslationProvider::init);
+
+        loadProvider();
+    }
+
+    public void handleMessage(String message, Cons<String> result) {
+        if (!enabled) {
+            result.get(message);
+            return;
+        }
+
+        currentProvider.translate(Strings.stripColors(message))
+                .thenAccept(translated -> {
+                    if (ChatTranslationConfig.isShowOriginal()) {
+                        result.get(message + "\n\n[][" + LanguageDialog.getDisplayName(Core.bundle.getLocale()) + "][] "
+                                + translated
+                                + "\n\n");
+                    } else {
+                        result.get(translated);
+                    }
+                })
+                .exceptionally(e -> {
+                    lastError = e.getMessage();
+
+                    result.get("[red]Translation Error[]: " + e.getMessage());
+
+                    Log.err("Translation failed", e);
+                    return null;
+                });
+
+    }
+
+    private void loadProvider() {
+        String id = ChatTranslationConfig.getProviderId();
+        currentProvider = providers.find(p -> p.getId().equals(id));
+
+        if (currentProvider == null) {
+            currentProvider = NOOP_PROVIDER;
+        }
+    }
+
+    @Override
+    public void onEnable() {
+        enabled = true;
+    }
+
+    @Override
+    public void onDisable() {
+        enabled = false;
+    }
+
+    @Override
+    public Optional<Dialog> setting() {
+        BaseDialog dialog = new BaseDialog("Chat Translation Settings");
+        dialog.addCloseButton();
+
+        Table root = new Table();
+        root.top().left().defaults().top().left().padBottom(5);
+
+        root.check("Show Original Message", ChatTranslationConfig.isShowOriginal(), val -> {
+            ChatTranslationConfig.setShowOriginal(val);
+        }).row();
+
+        root.image().height(4).color(Color.gray).fillX().pad(10).row();
+
+        root.add("Providers").style(Styles.outlineLabel).padBottom(5).row();
+
+        Table providerList = new Table();
+        ButtonGroup<Button> group = new ButtonGroup<>();
+        group.setMinCheckCount(1);
+
+        for (TranslationProvider prov : providers) {
+            Button card = new Button(Styles.togglet);
+            card.top().left().margin(12);
+
+            card.table(h -> {
+                h.left();
+                h.label(() -> prov.getName()).style(Styles.defaultLabel).growX().left();
+            }).growX().row();
+
+            card.collapser(s -> {
+                s.add(prov.settings()).growX().padTop(10);
+            }, false, card::isChecked).growX().row();
+
+            card.clicked(() -> {
+                if (currentProvider != prov) {
+                    currentProvider = prov;
+                    var isNoop = prov.getId().equals(NOOP_PROVIDER.getId());
+                    ChatTranslationConfig.setProviderId(prov.getId());
+                    FeatureManager.getInstance().setEnabled(this, !isNoop);
+                }
+            });
+
+            if (currentProvider == prov) {
+                card.setChecked(true);
+            }
+
+            group.add(card);
+            providerList.add(card).growX().padBottom(8).row();
+        }
+
+        root.add(providerList).growX().row();
+
+        root.label(() -> lastError == null ? "" : "Error: " + lastError)
+                .color(Color.red)
+                .visible(() -> lastError != null)
+                .row();
+
+        dialog.cont.pane(root).growX().maxWidth(700f).margin(20);
+        dialog.cont.pack();
+
+        return Optional.of(dialog);
+    }
+}

--- a/src/mindustrytool/features/chat/translation/DeepLTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/DeepLTranslationProvider.java
@@ -1,0 +1,139 @@
+package mindustrytool.features.chat.translation;
+
+import arc.Core;
+import arc.util.Http;
+import arc.util.Http.HttpStatusException;
+import arc.util.serialization.Jval;
+import arc.scene.ui.layout.Table;
+import arc.scene.ui.Slider;
+import java.util.concurrent.CompletableFuture;
+
+public class DeepLTranslationProvider implements TranslationProvider {
+    private static final String API_URL_FREE = "https://api-free.deepl.com/v2/translate";
+    private static final String API_URL_PRO = "https://api.deepl.com/v2/translate";
+
+    private String getApiKey() {
+        return Core.settings.getString(ChatTranslationConfig.DEEPL_API_KEY, "");
+    }
+
+    private void setApiKey(String key) {
+        Core.settings.put(ChatTranslationConfig.DEEPL_API_KEY, key);
+    }
+
+    private int getTimeout() {
+        return Core.settings.getInt(ChatTranslationConfig.DEEPL_TIMEOUT, 10);
+    }
+
+    private void setTimeout(int timeout) {
+        Core.settings.put(ChatTranslationConfig.DEEPL_TIMEOUT, timeout);
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public CompletableFuture<String> translate(String message) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        String apiKey = getApiKey();
+
+        if (apiKey.isEmpty()) {
+            future.complete(Core.bundle.get("chat-translation.deepl.no-api-key"));
+            return future;
+        }
+
+        String apiUrl = apiKey.endsWith(":fx") ? API_URL_FREE : API_URL_PRO;
+        String targetLang = Core.bundle.getLocale().getLanguage().toUpperCase();
+        
+        // DeepL deprecated "EN" and "PT" as target_lang in favor of "EN-GB"/"EN-US" and "PT-PT"/"PT-BR".
+        // However, the API might still accept "EN" and default to one. 
+        // If explicit handling is needed, we might need more complex locale logic.
+        // For now we rely on user's locale language code.
+        // Note: Java's getLanguage() returns "en", "de", etc.
+        
+        try {
+            Jval body = Jval.newObject();
+            Jval textArray = Jval.newArray();
+            textArray.add(message);
+            body.put("text", textArray);
+            body.put("target_lang", targetLang);
+
+            Http.post(apiUrl, body.toString())
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "DeepL-Auth-Key " + apiKey)
+                    .timeout(getTimeout() * 1000)
+                    .error(e -> {
+                         if (e instanceof HttpStatusException httpStatusException) {
+                            future.completeExceptionally(new RuntimeException(
+                                    Core.bundle.get("chat-translation.error.prefix")
+                                            + httpStatusException.response.getResultAsString()));
+                            return;
+                        }
+                        future.completeExceptionally(
+                                new RuntimeException(
+                                        Core.bundle.get("chat-translation.error.prefix") + e.getMessage()));
+                    })
+                    .submit(res -> {
+                        String jsonString = res.getResultAsString();
+                        try {
+                            Jval json = Jval.read(jsonString);
+                            // Response structure: { "translations": [ { "detected_source_language": "EN", "text": "Hallo, Welt!" } ] }
+                            if (json.has("translations") && !json.get("translations").asArray().isEmpty()) {
+                                String result = json.get("translations").asArray().get(0)
+                                        .getString("text", message).trim();
+                                future.complete(result);
+                            } else {
+                                future.complete(message);
+                            }
+                        } catch (Exception e) {
+                            future.completeExceptionally(
+                                    new RuntimeException(Core.bundle.get("chat-translation.deepl.parse-error"), e));
+                        }
+                    });
+
+        } catch (Exception e) {
+            future.completeExceptionally(new RuntimeException("DeepL translation error", e));
+        }
+
+        return future;
+    }
+
+    @Override
+    public Table settings() {
+        Table table = new Table();
+        table.add(Core.bundle.get("chat-translation.deepl.api-key-label")).left().row();
+        table.label(() -> Core.bundle.get("chat-translation.deepl.get-key-info"))
+                .style(mindustry.ui.Styles.outlineLabel)
+                .fontScale(0.8f)
+                .color(arc.graphics.Color.gray)
+                .left()
+                .row();
+
+        table.field(getApiKey(), this::setApiKey).growX().row();
+
+        table.add(Core.bundle.get("chat-translation.deepl.timeout-label") + ": " + getTimeout() + "s").left()
+                .padTop(10)
+                .update(l -> l
+                        .setText(Core.bundle.get("chat-translation.deepl.timeout-label") + ": " + getTimeout() + "s"))
+                .row();
+
+        Slider slider = new Slider(2, 20, 1, false);
+        slider.setValue(getTimeout());
+        slider.moved(val -> {
+            setTimeout((int) val);
+        });
+        table.add(slider).growX().row();
+
+        return table;
+    }
+
+    @Override
+    public String getName() {
+        return Core.bundle.get("chat-translation.provider.deepl");
+    }
+
+    @Override
+    public String getId() {
+        return "deepl";
+    }
+}

--- a/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
@@ -1,0 +1,113 @@
+package mindustrytool.features.chat.translation;
+
+import arc.Core;
+import arc.util.Http;
+import arc.util.Http.HttpStatusException;
+import arc.util.serialization.Jval;
+import arc.scene.ui.layout.Table;
+import java.util.concurrent.CompletableFuture;
+
+public class GeminiTranslationProvider implements TranslationProvider {
+    private static final String API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent";
+    private String apiKey = "";
+
+    @Override
+    public void init() {
+        apiKey = Core.settings.getString(ChatTranslationConfig.GEMINI_API_KEY, "");
+    }
+
+    @Override
+    public CompletableFuture<String> translate(String message) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        if (apiKey.isEmpty()) {
+            future.complete("[red]No API Key[]");
+            return future;
+        }
+
+        try {
+            Jval body = Jval.newObject();
+            Jval contents = Jval.newArray();
+            Jval content = Jval.newObject();
+            Jval parts = Jval.newArray();
+            Jval part = Jval.newObject();
+
+            String prompt = "Translate the following Mindustry game chat message to "
+                    + Core.bundle.getLocale().getDisplayName()
+                    + ". If it is already" + Core.bundle.getLocale().getDisplayName()
+                    + ", just return it as is. Message: "
+                    + message;
+
+            part.put("text", prompt);
+            parts.add(part);
+            content.put("parts", parts);
+            contents.add(content);
+            body.put("contents", contents);
+
+            Http.post(API_URL, body.toString())
+                    .header("Content-Type", "application/json")
+                    .header("x-goog-api-key", apiKey)
+                    .timeout(10000)
+                    .error(e -> {
+                        if (e instanceof HttpStatusException httpStatusException) {
+                            future.completeExceptionally(new RuntimeException(
+                                    "[red]Translation Error[]: " + httpStatusException.response.getResultAsString()));
+                            return;
+                        }
+                        future.completeExceptionally(
+                                new RuntimeException("[red]Translation Error[]: " + e.getMessage()));
+                    })
+                    .submit(res -> {
+                        String jsonString = res.getResultAsString();
+                        try {
+                            Jval json = Jval.read(jsonString);
+                            // Response structure: candidates[0].content.parts[0].text
+                            if (json.has("candidates") && !json.get("candidates").asArray().isEmpty()) {
+                                String result = json.get("candidates").asArray().get(0).asObject()
+                                        .get("content").asObject()
+                                        .get("parts").asArray().get(0)
+                                        .getString("text", message).trim();
+                                future.complete(result);
+                            } else {
+                                future.complete(message);
+                            }
+                        } catch (Exception e) {
+                            future.completeExceptionally(new RuntimeException("[red]Parse Error[]", e));
+                        }
+                    });
+        } catch (Exception e) {
+            future.completeExceptionally(new RuntimeException("Gemini translation error", e));
+        }
+
+        return future;
+    }
+
+    @Override
+    public Table settings() {
+        Table table = new Table();
+        table.add("Gemini API Key:").left().row();
+        table.label(() -> "Get key from Google AI Studio")
+                .style(mindustry.ui.Styles.outlineLabel)
+                .fontScale(0.8f)
+                .color(arc.graphics.Color.gray)
+                .left()
+                .row();
+
+        table.field(apiKey, val -> {
+            apiKey = val;
+            Core.settings.put(ChatTranslationConfig.GEMINI_API_KEY, val);
+        }).growX().valid(v -> !v.isEmpty() && v.startsWith("AIza")).row();
+
+        return table;
+    }
+
+    @Override
+    public String getName() {
+        return "Gemini AI";
+    }
+
+    @Override
+    public String getId() {
+        return "gemini";
+    }
+}

--- a/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
@@ -5,23 +5,56 @@ import arc.util.Http;
 import arc.util.Http.HttpStatusException;
 import arc.util.serialization.Jval;
 import arc.scene.ui.layout.Table;
+import arc.scene.ui.ButtonGroup;
+import arc.scene.ui.CheckBox;
+import arc.scene.ui.Slider;
+import mindustry.ui.Styles;
 import java.util.concurrent.CompletableFuture;
 
 public class GeminiTranslationProvider implements TranslationProvider {
-    private static final String API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent";
-    private String apiKey = "";
+    private static final String API_URL_BASE = "https://generativelanguage.googleapis.com/v1beta/models/";
+    private static final String[] MODELS = {
+            "gemini-2.0-flash-lite-preview-02-05",
+            "gemini-2.0-flash",
+            "gemini-1.5-flash",
+            "gemini-1.5-flash-8b",
+            "gemini-1.5-pro",
+    };
+
+    private String getApiKey() {
+        return Core.settings.getString(ChatTranslationConfig.GEMINI_API_KEY, "");
+    }
+
+    private void setApiKey(String key) {
+        Core.settings.put(ChatTranslationConfig.GEMINI_API_KEY, key);
+    }
+
+    private String getModel() {
+        return Core.settings.getString(ChatTranslationConfig.GEMINI_MODEL, MODELS[0]);
+    }
+
+    private void setModel(String model) {
+        Core.settings.put(ChatTranslationConfig.GEMINI_MODEL, model);
+    }
+
+    private int getTimeout() {
+        return Core.settings.getInt(ChatTranslationConfig.GEMINI_TIMEOUT, 10);
+    }
+
+    private void setTimeout(int timeout) {
+        Core.settings.put(ChatTranslationConfig.GEMINI_TIMEOUT, timeout);
+    }
 
     @Override
     public void init() {
-        apiKey = Core.settings.getString(ChatTranslationConfig.GEMINI_API_KEY, "");
     }
 
     @Override
     public CompletableFuture<String> translate(String message) {
         CompletableFuture<String> future = new CompletableFuture<>();
 
-        if (apiKey.isEmpty()) {
-            future.complete("[red]No API Key[]");
+        if (getApiKey().isEmpty()) {
+            future.complete(Core.bundle.get("chat-translation.gemini.no-api-key"));
             return future;
         }
 
@@ -44,18 +77,20 @@ public class GeminiTranslationProvider implements TranslationProvider {
             contents.add(content);
             body.put("contents", contents);
 
-            Http.post(API_URL, body.toString())
+            Http.post(API_URL_BASE + getModel() + ":generateContent", body.toString())
                     .header("Content-Type", "application/json")
-                    .header("x-goog-api-key", apiKey)
-                    .timeout(10000)
+                    .header("x-goog-api-key", getApiKey())
+                    .timeout(getTimeout() * 1000)
                     .error(e -> {
                         if (e instanceof HttpStatusException httpStatusException) {
                             future.completeExceptionally(new RuntimeException(
-                                    "[red]Translation Error[]: " + httpStatusException.response.getResultAsString()));
+                                    Core.bundle.get("chat-translation.error.prefix")
+                                            + httpStatusException.response.getResultAsString()));
                             return;
                         }
                         future.completeExceptionally(
-                                new RuntimeException("[red]Translation Error[]: " + e.getMessage()));
+                                new RuntimeException(
+                                        Core.bundle.get("chat-translation.error.prefix") + e.getMessage()));
                     })
                     .submit(res -> {
                         String jsonString = res.getResultAsString();
@@ -72,7 +107,8 @@ public class GeminiTranslationProvider implements TranslationProvider {
                                 future.complete(message);
                             }
                         } catch (Exception e) {
-                            future.completeExceptionally(new RuntimeException("[red]Parse Error[]", e));
+                            future.completeExceptionally(
+                                    new RuntimeException(Core.bundle.get("chat-translation.gemini.parse-error"), e));
                         }
                     });
         } catch (Exception e) {
@@ -85,25 +121,55 @@ public class GeminiTranslationProvider implements TranslationProvider {
     @Override
     public Table settings() {
         Table table = new Table();
-        table.add("Gemini API Key:").left().row();
-        table.label(() -> "Get key from Google AI Studio")
+        table.add(Core.bundle.get("chat-translation.gemini.api-key-label")).left().row();
+        table.label(() -> Core.bundle.get("chat-translation.gemini.get-key-info"))
                 .style(mindustry.ui.Styles.outlineLabel)
                 .fontScale(0.8f)
                 .color(arc.graphics.Color.gray)
                 .left()
                 .row();
 
-        table.field(apiKey, val -> {
-            apiKey = val;
-            Core.settings.put(ChatTranslationConfig.GEMINI_API_KEY, val);
-        }).growX().valid(v -> !v.isEmpty() && v.startsWith("AIza")).row();
+        table.field(getApiKey(), this::setApiKey).growX().valid(v -> !v.isEmpty() && v.startsWith("AIza")).row();
+
+        table.add(Core.bundle.get("chat-translation.gemini.model-label")).left().padTop(10).row();
+
+        Table modelTable = new Table();
+        ButtonGroup<CheckBox> group = new ButtonGroup<>();
+        for (String m : MODELS) {
+            CheckBox box = new CheckBox(m);
+            box.setStyle(Styles.defaultCheck);
+            box.changed(() -> {
+                if (box.isChecked()) {
+                    setModel(m);
+                }
+            });
+            if (getModel().equals(m)) {
+                box.setChecked(true);
+            }
+            group.add(box);
+            modelTable.add(box).left().padRight(10).row();
+        }
+        table.add(modelTable).left().row();
+
+        table.add(Core.bundle.get("chat-translation.gemini.timeout-label") + ": " + getTimeout() + "s").left()
+                .padTop(10)
+                .update(l -> l
+                        .setText(Core.bundle.get("chat-translation.gemini.timeout-label") + ": " + getTimeout() + "s"))
+                .row();
+
+        Slider slider = new Slider(2, 20, 1, false);
+        slider.setValue(getTimeout());
+        slider.moved(val -> {
+            setTimeout((int) val);
+        });
+        table.add(slider).growX().row();
 
         return table;
     }
 
     @Override
     public String getName() {
-        return "Gemini AI";
+        return Core.bundle.get("chat-translation.provider.gemini");
     }
 
     @Override

--- a/src/mindustrytool/features/chat/translation/NoopTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/NoopTranslationProvider.java
@@ -1,0 +1,31 @@
+package mindustrytool.features.chat.translation;
+
+import arc.scene.ui.layout.Table;
+
+import java.util.concurrent.CompletableFuture;
+
+public class NoopTranslationProvider implements TranslationProvider {
+    @Override
+    public CompletableFuture<String> translate(String message) {
+        return CompletableFuture.completedFuture(message);
+    }
+
+    @Override
+    public Table settings() {
+        return new Table();
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public String getName() {
+        return "None";
+    }
+
+    @Override
+    public String getId() {
+        return "noop";
+    }
+}

--- a/src/mindustrytool/features/chat/translation/NoopTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/NoopTranslationProvider.java
@@ -1,5 +1,6 @@
 package mindustrytool.features.chat.translation;
 
+import arc.Core;
 import arc.scene.ui.layout.Table;
 
 import java.util.concurrent.CompletableFuture;
@@ -21,7 +22,7 @@ public class NoopTranslationProvider implements TranslationProvider {
 
     @Override
     public String getName() {
-        return "None";
+        return Core.bundle.get("chat-translation.provider.none");
     }
 
     @Override

--- a/src/mindustrytool/features/chat/translation/TranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/TranslationProvider.java
@@ -1,0 +1,17 @@
+package mindustrytool.features.chat.translation;
+
+import arc.scene.ui.layout.Table;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface TranslationProvider {
+    CompletableFuture<String> translate(String message);
+
+    Table settings();
+
+    void init();
+
+    String getName();
+
+    String getId();
+}

--- a/src/mindustrytool/features/playerconnect/NetworkProxy.java
+++ b/src/mindustrytool/features/playerconnect/NetworkProxy.java
@@ -197,6 +197,8 @@ public class NetworkProxy extends Client implements NetListener {
                 Vars.ui.showText("[scarlet][[Server][] ", popupPacket.message);
             } else if (object instanceof Packets.RoomClosedPacket closedPacket) {
                 closeReason = closedPacket.reason;
+                Vars.ui.showText("[scarlet][[Server][] ", closedPacket.reason.toString());
+                close();
             } else if (object instanceof Packets.RoomLinkPacket roomLinkPacket) {
                 // Ignore if the room id is received twice
                 if (roomId != null) {

--- a/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
@@ -229,12 +229,14 @@ public class PlayerConnectRenderer {
             dialog.buttons.button("@cancel", dialog::hide).size(100, 50);
 
             dialog.buttons.button("Disable & Join", () -> {
-                unneeded.each(name -> {
-                    var mod = Vars.mods.getMod(name);
-                    if (mod != null) {
-                        Vars.mods.setEnabled(mod, false);
-                    }
-                });
+                unneeded
+                        .map(mod -> mod.substring(0, mod.indexOf(":")))
+                        .each(name -> {
+                            var mod = Vars.mods.getMod(name);
+                            if (mod != null) {
+                                Vars.mods.setEnabled(mod, false);
+                            }
+                        });
                 dialog.hide();
                 proceedToJoin(room);
             }).size(150, 50);

--- a/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
@@ -213,7 +213,7 @@ public class PlayerConnectRenderer {
         Seq<String> missing = serverMods.select(s -> localMods.contains(s));
         Seq<String> unneeded = localMods.select(m -> !serverMods.contains(m));
 
-        if (!unneeded.isEmpty() && !missing.isEmpty()) {
+        if (!unneeded.isEmpty() || !missing.isEmpty()) {
             BaseDialog dialog = new BaseDialog("@warning");
 
             if (!missing.isEmpty()) {


### PR DESCRIPTION
Fix the logic for detecting missing and unneeded mods when joining a server. Previously, the code incorrectly compared mod names without versions, leading to false positives. Now it uses the full mod strings (including versions) for accurate comparison. Also improve the join dialog to show both missing and unneeded mod warnings separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app chat translation with selectable providers (Gemini, DeepL, noop), provider settings, test/config UI, and option to show original messages.

* **Bug Fixes**
  * Improved mod compatibility checks and clearer prompts when joining multiplayer sessions.

* **Refactor**
  * Chat functionality reorganized under a global chat namespace.

* **UX**
  * Room closure now displays the server-provided close reason.

* **Chores**
  * Version bumped to v4.21.0-v8; added translation localization strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->