### PR TITLE
fix(chat): correct removeRange indices to preserve exact history size

### DIFF
--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -480,7 +480,7 @@ public class ChatOverlay extends Table {
         }
 
         if (messages.size > 1000) {
-            messages.removeRange(0, messages.size - 1000);
+            messages.removeRange(0, messages.size - 1000 - 1);
         }
 
         if (messageTable != null && !config.collapsed()) {

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -358,11 +358,10 @@ public class ChatOverlay extends Table {
                 if (scrollPane != null) {
                     scrollPane.setScrollY(scrollPane.getMaxY());
                 }
+
+                Core.scene.setKeyboardFocus(inputField);
             });
 
-            if (inputField != null && !config.collapsed()) {
-                Core.scene.setKeyboardFocus(inputField);
-            }
         }
 
         pack();
@@ -477,6 +476,8 @@ public class ChatOverlay extends Table {
         if (config.collapsed() && addedCount > 0) {
             unreadCount += addedCount;
             updateBadge();
+        } else {
+            config.lastRead(Instant.now());
         }
 
         if (messages.size > 1000) {
@@ -690,6 +691,8 @@ public class ChatOverlay extends Table {
                     if (sendButton != null) {
                         sendButton.setText("@chat.send");
                     }
+
+                    Core.scene.setKeyboardFocus(inputField);
                 });
             }).exceptionally((err) -> {
                 isSending.set(false);

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -93,7 +93,7 @@ public class ChatTranslationFeature implements Feature {
                 .thenApply(translated -> {
                     if (ChatTranslationConfig.isShowOriginal()) {
                         String locale = LanguageDialog.getDisplayName(Core.bundle.getLocale());
-                        String formated = Strings.format("@\n\n[]@[]@\n\n", message, locale, translated);
+                        String formated = Strings.format("[]@[]\n\n[]@[]@\n\n", message, locale, translated);
 
                         return formated;
                     }
@@ -104,7 +104,7 @@ public class ChatTranslationFeature implements Feature {
                 .exceptionally(e -> {
                     lastError = e.getMessage();
 
-                    String formated = Strings.format("@\n\n@\n\n", message,
+                    String formated = Strings.format("[]@[]\n\n[]@[]\n\n", message,
                             Core.bundle.get("chat-translation.error.prefix") + e.getMessage());
 
                     cons.get(formated);

--- a/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
@@ -69,7 +69,7 @@ public class GeminiTranslationProvider implements TranslationProvider {
         lastMessages.add(message);
 
         if (lastMessages.size > maxHistory()) {
-            lastMessages.removeRange(0, lastMessages.size - maxHistory());
+            lastMessages.removeRange(0, lastMessages.size - maxHistory() - 1);
         }
 
         CompletableFuture<String> future = new CompletableFuture<>();

--- a/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
+++ b/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
@@ -204,7 +204,7 @@ public class CreateRoomDialog extends BaseDialog {
                     .left()
                     .padBottom(5f)
                     .row();
-        }).growX().maxWidth(800f).padBottom(20f).row();
+        }).growX().maxWidth(800f).padBottom(20f).margin(20).row();
 
         mainTable.button("@next", Icon.right, () -> {
             setupStep2();

--- a/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
+++ b/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
@@ -245,7 +245,7 @@ public class CreateRoomDialog extends BaseDialog {
         }).size(200f, 50f).padRight(10f);
 
         buttons.button("@message.create-room.create-room", Icon.play, () -> {
-            createRoom(PlayerConnectConfig.getPassword());
+            createRoom();
         }).size(200f, 50f).disabled(b -> selected == null);
 
         mainTable.add(buttons).row();
@@ -353,9 +353,10 @@ public class CreateRoomDialog extends BaseDialog {
         }
     }
 
-    public void createRoom(String password) {
-        if (selected == null)
+    public void createRoom() {
+        if (selected == null) {
             return;
+        }
 
         Vars.netServer.admins.setPlayerLimit(PlayerConnectConfig.getMaxPlayer());
 
@@ -367,7 +368,7 @@ public class CreateRoomDialog extends BaseDialog {
             PlayerConnect.close();
         }, 10);
 
-        PlayerConnect.create(selected.ip, selected.port, password, link -> {
+        PlayerConnect.create(selected.ip, selected.port, link -> {
             Vars.ui.loadfrag.hide();
             timer.cancel();
             this.link = link;

--- a/src/mindustrytool/features/playerconnect/NetworkProxy.java
+++ b/src/mindustrytool/features/playerconnect/NetworkProxy.java
@@ -50,13 +50,12 @@ public class NetworkProxy extends Client implements NetListener {
 
     private String roomId = null;
     private RoomCloseReason closeReason;
-    private String password = "";
     private String remoteHost = "";
 
     private Cons<String> onRoomCreated;
     private Cons<RoomCloseReason> onRoomClosed;
 
-    public NetworkProxy(String password) {
+    public NetworkProxy() {
         super(32768, 16384, new Serializer());
 
         addListener(this);
@@ -69,7 +68,6 @@ public class NetworkProxy extends Client implements NetListener {
 
         server = Reflect.get(provider, "server");
         serverDispatcher = Reflect.get(server, "dispatchListener");
-        this.password = password;
     }
 
     public void connect(String host, int udpTcpPort, Cons<String> onRoomCreated,
@@ -84,10 +82,6 @@ public class NetworkProxy extends Client implements NetListener {
 
     public String getRemoteHost() {
         return remoteHost;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
     }
 
     /**
@@ -158,7 +152,7 @@ public class NetworkProxy extends Client implements NetListener {
             Packets.RoomStats stats = getStats();
             Packets.RoomCreationRequestPacket p = new Packets.RoomCreationRequestPacket(
                     PROTOCOL_VERSION,
-                    password,
+                    PlayerConnectConfig.getPassword(),
                     stats);
 
             sendTCP(p);
@@ -364,6 +358,7 @@ public class NetworkProxy extends Client implements NetListener {
         public VirtualConnection(NetworkProxy proxy, int id) {
             this.proxy = proxy;
             this.id = id;
+
             addListener(proxy.serverDispatcher);
 
             Log.info("Client connection created with id: @", id);

--- a/src/mindustrytool/features/playerconnect/PlayerConnect.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnect.java
@@ -143,7 +143,6 @@ public class PlayerConnect {
     }
 
     public static void create(String ip, int port,
-            String password,
             Cons<PlayerConnectLink> onSucceed,
             Cons<Throwable> onFailed,
             Cons<RoomCloseReason> onDisconnected//
@@ -153,9 +152,8 @@ public class PlayerConnect {
         }
 
         if (room == null || roomThread == null || !roomThread.isAlive()) {
-            room = new NetworkProxy(password);
+            room = new NetworkProxy();
             roomThread = Threads.daemon("Proxy", room);
-
         }
 
         worker.submit(() -> {
@@ -212,14 +210,13 @@ public class PlayerConnect {
                 throw new IllegalStateException("Net client is not active.");
             }
 
-            // We need to serialize the packet manually
-            tmpBuffer.clear();
-
             var packet = new Packets.RoomJoinPacket(link.roomId, password);
 
             tmpSerializer.write(tmpBuffer, packet);
             tmpBuffer.limit(tmpBuffer.position()).position(0);
             Vars.net.send(tmpBuffer, true);
+
+            Vars.netClient.beginConnecting();
 
             success.run();
         });


### PR DESCRIPTION
- Adjust indices in ChatOverlay and GeminiTranslationProvider to keep exactly the configured number of messages, preventing off-by-one errors.
- Add margin to CreateRoomDialog layout for better visual spacing.
- Refactor ChatTranslationFeature to streamline translation result handling and remove unused import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat history trimming so messages are retained correctly within limits.
  * Improved unread badge and last-read tracking when chat is collapsed or updated.
  * Improved translation error handling and fallback messaging.

* **New Features / Improvements**
  * Chat input now reliably regains keyboard focus after layout and after sending.
  * Translation option can show original message alongside locale when enabled.
  * Simplified room creation flow with clearer success/error feedback and spacing; connection startup timing improved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->