### PR TITLE
fix(ui): fix IPv6 address formatting and chat translation error display

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.24.3-v8
+version: v4.24.5-v8
 
 minGameVersion: 154
 

--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.24.2-v8
+version: v4.24.3-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/auth/AuthHttp.java
+++ b/src/mindustrytool/features/auth/AuthHttp.java
@@ -64,9 +64,9 @@ public class AuthHttp {
                         HttpRequest req;
                         if (method == HttpMethod.GET) {
                             req = Http
-                                    .get(url).timeout(5000);
+                                    .get(url).timeout(10000);
                         } else {
-                            req = Http.post(url, content).timeout(5000);
+                            req = Http.post(url, content).timeout(10000);
                         }
 
                         String token = AuthService.getInstance().getAccessToken();

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -92,7 +92,7 @@ public class AuthService {
         Core.scene.add(dialog);
 
         Http.get(Config.API_v4_URL + "auth/app/login-uri")
-                .timeout(5000)
+                .timeout(10000)
                 .error(err -> {
                     dialog.hide();
                     dialog.remove();
@@ -274,7 +274,7 @@ public class AuthService {
 
         Http.post(Config.API_v4_URL + "auth/app/refresh", json.toString())
                 .header("Content-Type", "application/json")
-                .timeout(5000)
+                .timeout(10000)
                 .error(err -> {
                     Log.err("Failed to refresh token", err);
 

--- a/src/mindustrytool/features/chat/pretty/PrettyChatFeature.java
+++ b/src/mindustrytool/features/chat/pretty/PrettyChatFeature.java
@@ -7,6 +7,7 @@ import arc.Events;
 import arc.scene.ui.Dialog;
 import arc.scene.ui.TextField;
 import arc.struct.Seq;
+import arc.util.Log;
 import arc.util.Reflect;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -97,13 +98,17 @@ public class PrettyChatFeature implements Feature {
         Events.run(Trigger.update, () -> {
             if (Core.input.keyTap(Binding.chat) && Vars.ui.chatfrag.shown()) {
                 Core.app.post(() -> {
-                    TextField chatfield = Reflect.get(Vars.ui.chatfrag, "chatfield");
+                    try {
+                        TextField chatfield = Reflect.get(Vars.ui.chatfrag, "chatfield");
 
-                    if (chatfield == null) {
-                        return;
+                        if (chatfield == null) {
+                            return;
+                        }
+
+                        chatfield.setText(transform(chatfield.getText()));
+                    } catch (Exception e) {
+                        Log.err(e);
                     }
-
-                    chatfield.setText(transform(chatfield.getText()));
                 });
             }
         });

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -28,11 +28,11 @@ import arc.struct.Seq;
 import java.util.Optional;
 
 public class ChatTranslationFeature implements Feature {
-    private final TranslationProvider NOOP_PROVIDER = new NoopTranslationProvider();
-    private final Seq<TranslationProvider> providers = new Seq<>();
-    private TranslationProvider currentProvider = NOOP_PROVIDER;
-    private String lastError = null;
-    private boolean enabled = false;
+    private static final Seq<TranslationProvider> providers = new Seq<>();
+    private static final TranslationProvider NOOP_PROVIDER = new NoopTranslationProvider();
+    private static String lastError = null;
+    private static TranslationProvider currentProvider = NOOP_PROVIDER;
+    private static boolean enabled = false;
 
     @Override
     public FeatureMetadata getMetadata() {
@@ -83,7 +83,7 @@ public class ChatTranslationFeature implements Feature {
 
     }
 
-    public void handleMessage(String message, Cons<String> cons) {
+    public static void handleMessage(String message, Cons<String> cons) {
         if (!enabled) {
             cons.get(message);
             return;
@@ -104,7 +104,7 @@ public class ChatTranslationFeature implements Feature {
                 .exceptionally(e -> {
                     lastError = e.getMessage();
 
-                    String formated = Strings.format("[]@[]\n\n[]@[]\n\n", message,
+                    String formated = Strings.format("@\n\n[scarlet]@[]\n\n", message,
                             Core.bundle.get("chat-translation.error.prefix") + e.getMessage());
 
                     cons.get(formated);

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -28,11 +28,11 @@ import arc.struct.Seq;
 import java.util.Optional;
 
 public class ChatTranslationFeature implements Feature {
-    private static final Seq<TranslationProvider> providers = new Seq<>();
-    private static final TranslationProvider NOOP_PROVIDER = new NoopTranslationProvider();
-    private static String lastError = null;
-    private static TranslationProvider currentProvider = NOOP_PROVIDER;
-    private static boolean enabled = false;
+    private final Seq<TranslationProvider> providers = new Seq<>();
+    private final TranslationProvider NOOP_PROVIDER = new NoopTranslationProvider();
+    private String lastError = null;
+    private TranslationProvider currentProvider = NOOP_PROVIDER;
+    private boolean enabled = false;
 
     @Override
     public FeatureMetadata getMetadata() {
@@ -83,7 +83,7 @@ public class ChatTranslationFeature implements Feature {
 
     }
 
-    public static void handleMessage(String message, Cons<String> cons) {
+    public void handleMessage(String message, Cons<String> cons) {
         if (!enabled) {
             cons.get(message);
             return;

--- a/src/mindustrytool/features/chat/translation/DeepLTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/DeepLTranslationProvider.java
@@ -44,13 +44,7 @@ public class DeepLTranslationProvider implements TranslationProvider {
 
         String apiUrl = apiKey.endsWith(":fx") ? API_URL_FREE : API_URL_PRO;
         String targetLang = Core.bundle.getLocale().getLanguage().toUpperCase();
-        
-        // DeepL deprecated "EN" and "PT" as target_lang in favor of "EN-GB"/"EN-US" and "PT-PT"/"PT-BR".
-        // However, the API might still accept "EN" and default to one. 
-        // If explicit handling is needed, we might need more complex locale logic.
-        // For now we rely on user's locale language code.
-        // Note: Java's getLanguage() returns "en", "de", etc.
-        
+
         try {
             Jval body = Jval.newObject();
             Jval textArray = Jval.newArray();
@@ -63,7 +57,7 @@ public class DeepLTranslationProvider implements TranslationProvider {
                     .header("Authorization", "DeepL-Auth-Key " + apiKey)
                     .timeout(getTimeout() * 1000)
                     .error(e -> {
-                         if (e instanceof HttpStatusException httpStatusException) {
+                        if (e instanceof HttpStatusException httpStatusException) {
                             future.completeExceptionally(new RuntimeException(
                                     Core.bundle.get("chat-translation.error.prefix")
                                             + httpStatusException.response.getResultAsString()));
@@ -77,7 +71,6 @@ public class DeepLTranslationProvider implements TranslationProvider {
                         String jsonString = res.getResultAsString();
                         try {
                             Jval json = Jval.read(jsonString);
-                            // Response structure: { "translations": [ { "detected_source_language": "EN", "text": "Hallo, Welt!" } ] }
                             if (json.has("translations") && !json.get("translations").asArray().isEmpty()) {
                                 String result = json.get("translations").asArray().get(0)
                                         .getString("text", message).trim();

--- a/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
+++ b/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
@@ -328,6 +328,8 @@ public class CreateRoomDialog extends BaseDialog {
                 label.add(servers.getKeyAt(i) + " [lightgray](" + servers.getValueAt(i) + ')').pad(2).expandX();
             }
 
+            label.marginLeft(10).marginRight(10);
+
             stack.add(label);
             stack.add(inner);
 

--- a/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
+++ b/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
@@ -14,6 +14,7 @@ import arc.util.Log;
 import arc.util.Strings;
 import arc.util.Time;
 import arc.util.Timer;
+import arc.util.Http.HttpStatusException;
 import mindustry.Vars;
 import mindustry.game.EventType;
 import mindustry.gen.Icon;
@@ -278,9 +279,15 @@ public class CreateRoomDialog extends BaseDialog {
             refreshingOnline = false;
             Vars.ui.showInfoFade("@message.room.fetch-failed");
 
+            String message = e.getMessage();
+
+            if (e instanceof HttpStatusException httpStatusException) {
+                message = httpStatusException.response.getResultAsString();
+            }
+
             if (online != null) {
                 online.clear();
-                online.add("fetch failed")
+                online.add(message)
                         .color(Pal.accent)
                         .labelAlign(Align.center)
                         .growX()

--- a/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
+++ b/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
@@ -450,7 +450,7 @@ public class CreateRoomDialog extends BaseDialog {
             if (!wasValid)
                 return "";
             else if (Strings.count(ip, ':') > 1)
-                return "[" + ip + "]:" + port;
+                return "[[" + ip + "]]:" + port;
             else
                 return ip + ":" + port;
         }

--- a/src/mindustrytool/services/PlayerConnectService.java
+++ b/src/mindustrytool/services/PlayerConnectService.java
@@ -18,7 +18,7 @@ public class PlayerConnectService {
     @SuppressWarnings("unchecked")
     public void findPlayerConnectRooms(String q, Cons<Seq<PlayerConnectRoom>> cons) {
         Http.get(Config.API_v4_URL + "player-connect/rooms?q=" + q)
-                .timeout(5000)
+                .timeout(10000)
                 .error(_err -> Core.app.post(() -> cons.get(new Seq<>())))
                 .submit(response -> {
                     String data = response.getResultAsString();
@@ -38,7 +38,7 @@ public class PlayerConnectService {
             Cons<Throwable> onFailed) {
 
         Http.get(Config.API_v4_URL + "player-connect/providers")
-                .timeout(5000)
+                .timeout(10000)
                 .error(onFailed)
                 .submit(response -> {
                     String data = response.getResultAsString();

--- a/src/mindustrytool/services/UserService.java
+++ b/src/mindustrytool/services/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
             listeners.put(id, callbacks);
 
             Http.get(Config.API_URL + "users/" + id)
-                    .timeout(5000)
+                    .timeout(10000)
                     .submit(response -> {
                         String data = response.getResultAsString();
                         UserData userData = JsonIO.json.fromJson(UserData.class, data);

--- a/src/mindustrytool/ui/NetworkImage.java
+++ b/src/mindustrytool/ui/NetworkImage.java
@@ -96,7 +96,7 @@ public class NetworkImage extends Image {
 
                 } else {
                     Http.get(url + "?format=jpeg")
-                            .timeout(5000)
+                            .timeout(10000)
                             .error(error -> {
                                 isError = true;
                                 if (!(error instanceof HttpStatusException requestError)


### PR DESCRIPTION
- Use double brackets for IPv6 addresses in room creation to avoid parsing issues
- Change chat translation error formatting to use proper color markup and remove redundant prefix
- Make chat translation fields static to ensure consistent state across instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version updated to v4.24.3-v8.

* **Improvements**
  * Crash report submission made non-blocking to avoid UI hangs.
  * Chat translation error formatting improved for clarity.
  * Connection dialog displays more detailed server error messages on fetch failure.
  * Minor UI spacing adjusted for server list labels.
  * IPv6 address display format corrected.
  * Chat toggle now guards against unexpected errors and logs failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->