### PR TITLE
perf: use object pooling for GlyphLayout instances

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.25.2-v8
+version: v4.25.3-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/browser/FilterDialog.java
+++ b/src/mindustrytool/features/browser/FilterDialog.java
@@ -11,6 +11,7 @@ import arc.scene.ui.layout.Table;
 import arc.struct.Seq;
 import arc.util.Align;
 import arc.util.Log;
+import arc.util.pooling.Pools;
 import mindustry.Vars;
 import mindustry.ui.Styles;
 import mindustry.ui.dialogs.BaseDialog;
@@ -23,7 +24,6 @@ import mindustrytool.ui.NetworkImage;
 
 public class FilterDialog extends BaseDialog {
     private static final float TARGET_WIDTH = 250f;
-    private final GlyphLayout layout = new GlyphLayout();
 
     private TextButtonStyle style = Styles.togglet;
     private final Cons<Cons<Seq<TagCategory>>> tagProvider;
@@ -238,6 +238,8 @@ public class FilterDialog extends BaseDialog {
 
         float currentWidth = 0;
 
+        GlyphLayout layout = Pools.obtain(GlyphLayout.class, GlyphLayout::new);
+
         for (var tag: tags) {
             String tagName = formatTag(tag.name());
             float iconSize = (tag.icon() != null && !tag.icon().isEmpty()) ? 40 * scale + 8 : 0;
@@ -281,6 +283,8 @@ public class FilterDialog extends BaseDialog {
 
             currentWidth += buttonWidth + CARD_GAP;
         }
+
+        Pools.free(layout);
 
         table.add(container).width(availableWidth).left().padBottom(48);
     }

--- a/src/mindustrytool/features/chat/translation/DeepLTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/DeepLTranslationProvider.java
@@ -35,10 +35,12 @@ public class DeepLTranslationProvider implements TranslationProvider {
     @Override
     public CompletableFuture<String> translate(String message) {
         CompletableFuture<String> future = new CompletableFuture<>();
+
         String apiKey = getApiKey();
 
         if (apiKey.isEmpty()) {
-            future.complete(Core.bundle.get("chat-translation.deepl.no-api-key"));
+            future.completeExceptionally(
+                    new IllegalArgumentException(Core.bundle.get("chat-translation.deepl.no-api-key")));
             return future;
         }
 

--- a/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/GeminiTranslationProvider.java
@@ -75,7 +75,9 @@ public class GeminiTranslationProvider implements TranslationProvider {
         CompletableFuture<String> future = new CompletableFuture<>();
 
         if (getApiKey().isEmpty()) {
-            future.complete(Core.bundle.get("chat-translation.gemini.no-api-key"));
+            future.completeExceptionally(
+                    new IllegalArgumentException(Core.bundle.get("chat-translation.gemini.no-api-key")));
+
             return future;
         }
 

--- a/src/mindustrytool/features/display/teamresource/SplitBar.java
+++ b/src/mindustrytool/features/display/teamresource/SplitBar.java
@@ -7,6 +7,7 @@ import arc.graphics.g2d.GlyphLayout;
 import arc.scene.Element;
 import arc.struct.Seq;
 import arc.util.Log;
+import arc.util.pooling.Pools;
 import mindustry.core.UI;
 import mindustry.gen.Tex;
 import mindustry.graphics.Pal;
@@ -31,8 +32,9 @@ public class SplitBar extends Element {
 
     @Override
     public void draw() {
-        Draw.color(Color.black);
+        Draw.reset();
 
+        Draw.color(Color.black);
         Tex.whiteui.draw(x, y, width, height);
 
         if (graphs.isEmpty()) {
@@ -47,9 +49,11 @@ public class SplitBar extends Element {
         if (totalWeight <= 0.0001f) {
 
         } else {
+            GlyphLayout layout = Pools.obtain(GlyphLayout.class, GlyphLayout::new);
             float currentX = x;
 
             Font font = Fonts.outline;
+
             float originalScaleX = font.getScaleX();
             float originalScaleY = font.getScaleY();
 
@@ -86,7 +90,6 @@ public class SplitBar extends Element {
                 String text = getSectionText(graph);
                 if (!text.isEmpty()) {
                     try {
-                        GlyphLayout layout = new GlyphLayout();
                         layout.setText(font, text);
 
                         if (layout.width < sectionWidth - 4f) {
@@ -103,8 +106,10 @@ public class SplitBar extends Element {
             }
 
             font.getData().setScale(originalScaleX, originalScaleY);
+            Pools.free(layout);
             Draw.reset();
         }
+
     }
 
     private float getWeight(PowerGraph graph) {

--- a/src/mindustrytool/features/settings/FeatureSettingDialog.java
+++ b/src/mindustrytool/features/settings/FeatureSettingDialog.java
@@ -8,6 +8,8 @@ import arc.Core;
 import arc.graphics.Color;
 import arc.scene.Element;
 import arc.scene.Group;
+import arc.scene.event.ClickListener;
+import arc.scene.event.InputEvent;
 import arc.scene.ui.layout.Scl;
 import arc.scene.ui.layout.Table;
 import arc.util.Scaling;
@@ -167,7 +169,13 @@ public class FeatureSettingDialog extends BaseDialog {
                         header.button(Icon.settings, Styles.clearNonei,
                                 () -> feature.setting().ifPresent(dialog -> Core.app.post(() -> dialog.show())))
                                 .size(32)
-                                .padLeft(8);
+                                .padLeft(8)
+                                .get().addListener(new ClickListener() {
+                                    @Override
+                                    public void clicked(InputEvent event, float x, float y) {
+                                        event.stop();
+                                    }
+                                });
                     }
 
                     // Status icon (visual only)
@@ -224,7 +232,13 @@ public class FeatureSettingDialog extends BaseDialog {
                         header.button(Icon.settings, Styles.clearNonei,
                                 () -> feature.setting().ifPresent(dialog -> Core.app.post(() -> dialog.show())))
                                 .size(32)
-                                .padLeft(8);
+                                .padLeft(8)
+                                .get().addListener(new ClickListener() {
+                                    @Override
+                                    public void clicked(InputEvent event, float x, float y) {
+                                        event.stop();
+                                    }
+                                });
                     }
 
                     // Status icon (visual only)
@@ -253,9 +267,16 @@ public class FeatureSettingDialog extends BaseDialog {
         })
                 .growX()
                 .minWidth(cardWidth)
-                .height(180f).pad(10f).get().clicked(() -> {
-                    FeatureManager.getInstance().setEnabled(feature, !enabled);
-                    rebuild();
+                .height(180f).pad(10f).get().addListener(new ClickListener() {
+                    @Override
+                    public void clicked(InputEvent event, float x, float y) {
+                        if (event.stopped) {
+                            return;
+                        }
+
+                        FeatureManager.getInstance().setEnabled(feature, !enabled);
+                        rebuild();
+                    }
                 });
     }
 }


### PR DESCRIPTION
Replace direct GlyphLayout instantiation with pool allocation in FilterDialog and SplitBar to reduce garbage collection overhead during UI rendering cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to v4.25.3-v8
  * Internal performance optimizations and improved memory efficiency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->