### PR TITLE
fix(autoplay): prevent NPE when dialog is null during task update

### DIFF
--- a/src/mindustrytool/features/autoplay/AutoplayFeature.java
+++ b/src/mindustrytool/features/autoplay/AutoplayFeature.java
@@ -160,7 +160,7 @@ public class AutoplayFeature implements Feature {
 
             currentTask = nextTask;
 
-            if (dialog.visible) {
+            if (dialog != null && dialog.visible) {
                 dialog.rebuild();
             }
         }


### PR DESCRIPTION
Check for null dialog before accessing its visible property to avoid NullPointerException when rebuilding UI during autoplay task transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash condition in the autoplay functionality to improve application stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->