### PR TITLE
fix(ui): prevent feature rendering when HUD is hidden

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.34.4-v8
+version: v4.35.0-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -114,7 +114,7 @@ public class AuthService {
                         loginDialog.cont.button(loginUrl, () -> {
                             Core.app.setClipboardText(loginUrl);
                             Vars.ui.showInfoFade("@copied");
-                        }).margin(40).growX().wrapLabel(true);
+                        }).margin(40).growX().wrapLabel(true).fontScale(0.5f);
 
                         Core.settings.put(KEY_LOGIN_ID, loginId);
 

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -81,16 +81,16 @@ public class AuthService {
 
         if (loginDialog == null) {
             loginDialog = new BaseDialog("@login");
+            loginDialog.name = "loginDialog";
+
+            loginDialog.buttons.button("@cancel", () -> {
+                if (!loginFuture.isDone()) {
+                    loginFuture.completeExceptionally(new RuntimeException("Login cancelled"));
+                }
+                loginDialog.hide();
+            }).width(230);
+
         }
-
-        loginDialog.name = "loginDialog";
-
-        loginDialog.buttons.button("@cancel", () -> {
-            if (!loginFuture.isDone()) {
-                loginFuture.completeExceptionally(new RuntimeException("Login cancelled"));
-            }
-            loginDialog.hide();
-        }).width(230);
 
         loginDialog.cont.add("@generate-loading-link");
         Core.app.post(() -> loginDialog.show());

--- a/src/mindustrytool/features/browser/map/MapDialog.java
+++ b/src/mindustrytool/features/browser/map/MapDialog.java
@@ -48,7 +48,6 @@ public class MapDialog extends BaseDialog {
     private final MapInfoDialog infoDialog = new MapInfoDialog();
     private final Debouncer debouncer = new Debouncer(500, TimeUnit.MILLISECONDS);
     private final TagService tagService = new TagService();
-    private final MapService mapService = new MapService();
 
     private static SearchConfig searchConfig = new SearchConfig();
 
@@ -249,10 +248,10 @@ public class MapDialog extends BaseDialog {
             preview.table(buttons -> {
                 buttons.center().defaults().size(PREVIEW_BUTTON_SIZE);
 
-                buttons.button(Icon.download, Styles.emptyi, () -> handleDownloadMap(data))
+                buttons.button(Icon.download, Styles.emptyi, () -> handleDownloadMap(data.getId()))
                         .pad(2);
                 buttons.button(Icon.info, Styles.emptyi,
-                        () -> mapService.findMapById(data.getId())
+                        () -> MapService.findMapById(data.getId())
                                 .thenAccept(m -> Core.app.post(() -> infoDialog.show(m))))
                         .tooltip("@info.title");
             }).growX().height(PREVIEW_BUTTON_SIZE);
@@ -300,7 +299,7 @@ public class MapDialog extends BaseDialog {
             return;
         }
 
-        mapService.findMapById(data.getId()).thenAccept(m -> Core.app.post(() -> infoDialog.show(m)));
+        MapService.findMapById(data.getId()).thenAccept(m -> Core.app.post(() -> infoDialog.show(m)));
     }
 
     private void rebuildFooter() {
@@ -378,11 +377,11 @@ public class MapDialog extends BaseDialog {
         rebuildFooter();
     }
 
-    private void handleDownloadMap(MapData map) {
-        mapService.downloadMap(map.getId()).thenAccept(result -> {
+    public static void handleDownloadMap(String id) {
+        MapService.downloadMap(id).thenAccept(result -> {
             Core.app.post(() -> {
                 try {
-                    Fi mapFile = Vars.customMapDirectory.child(map.getId());
+                    Fi mapFile = Vars.customMapDirectory.child(id);
                     mapFile.writeBytes(result);
                     Vars.maps.importMap(mapFile);
                     ui.showInfoFade("@map.saved");

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -532,7 +532,7 @@ public class ChatOverlay extends Table {
                 rebuildMessages(messageTable);
             });
 
-            Time.runTask(30, () -> {
+            Time.runTask(10, () -> {
                 if (scrollPane != null) {
                     Core.app.post(() -> scrollPane.setScrollY(scrollPane.getMaxY()));
                 }

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -532,7 +532,7 @@ public class ChatOverlay extends Table {
                 rebuildMessages(messageTable);
             });
 
-            Time.runTask(60 * 3, () -> {
+            Time.runTask(30, () -> {
                 if (scrollPane != null) {
                     Core.app.post(() -> scrollPane.setScrollY(scrollPane.getMaxY()));
                 }

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -557,6 +557,8 @@ public class ChatOverlay extends Table {
                         avatar.clear();
                         if (data.getImageUrl() != null && !data.getImageUrl().isEmpty()) {
                             avatar.add(new NetworkImage(data.getImageUrl())).size(40);
+                        } else {
+                            avatar.add(new Image(Icon.players)).size(40);
                         }
                     });
                 });
@@ -754,6 +756,8 @@ public class ChatOverlay extends Table {
             // Avatar
             if (user.getImageUrl() != null && !user.getImageUrl().isEmpty()) {
                 card.add(new NetworkImage(user.getImageUrl())).size(40).padRight(8);
+            } else {
+                card.add(new Image(Icon.players)).size(40).padRight(8);
             }
 
             // Info Table

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -38,6 +38,11 @@ import mindustrytool.Utils;
 import mindustrytool.features.auth.AuthService;
 import mindustrytool.features.auth.dto.LoginEvent;
 import mindustrytool.features.auth.dto.LogoutEvent;
+import mindustrytool.features.browser.map.MapDialog;
+import mindustrytool.features.browser.map.MapImage;
+import mindustrytool.features.browser.map.MapInfoDialog;
+import mindustrytool.features.browser.schematic.SchematicDialog;
+import mindustrytool.features.browser.schematic.SchematicInfoDialog;
 import mindustrytool.features.chat.global.dto.ChatMessage;
 import mindustrytool.features.chat.global.dto.ChatStateChange;
 import mindustrytool.features.chat.global.dto.ChatUser;
@@ -52,14 +57,25 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import mindustrytool.features.chat.global.dto.ChatUser.SimpleRole;
 import mindustrytool.features.playerconnect.PlayerConnectLink;
 import mindustrytool.features.playerconnect.PlayerConnectRenderer;
+import mindustrytool.services.MapService;
 import mindustrytool.services.PlayerConnectService;
+import mindustrytool.services.SchematicService;
 import mindustrytool.services.State;
 
 public class ChatOverlay extends Table {
+    private static final Pattern MINDUSTRY_TOOL_LINK_PATTERN = Pattern
+            .compile("^https?://[^/]+/[^/]+/(schematics|maps)/([0-9a-fA-F-]+)");
+
+    private static final float TARGET_WIDTH = 250f;
+    private static final float PREVIEW_BUTTON_SIZE = 50f;
+    private static final float CARD_HEIGHT = 330f;
+
     private Seq<ChatMessage> messages = new Seq<>();
     private Table messageTable;
     private Table userListTable;
@@ -82,6 +98,9 @@ public class ChatOverlay extends Table {
     private boolean isUserListCollapsed;
     private Image connectionIndicator;
 
+    private final SchematicInfoDialog schematicInfoDialog = new SchematicInfoDialog();
+    private final MapInfoDialog mapInfoDialog = new MapInfoDialog();
+
     public ChatOverlay() {
         name = "mdt-chat-overlay";
         touchable = Touchable.childrenOnly;
@@ -93,6 +112,8 @@ public class ChatOverlay extends Table {
         inputTable = new Table();
 
         containerCell = add(container);
+
+        visible(() -> Vars.ui.hudfrag != null && Vars.ui.hudfrag.shown);
 
         inputField = new TextField();
         inputField.setMessageText("@chat.enter-message");
@@ -527,9 +548,8 @@ public class ChatOverlay extends Table {
 
         for (ChatMessage msg : messages) {
             Table entry = new Table();
-            entry.setBackground(null); // Clear background
 
-            // Avatar Column
+            entry.setBackground(null);
             entry.table(avatar -> {
                 avatar.top();
                 UserService.findUserById(msg.createdBy).thenAccept(data -> {
@@ -542,7 +562,6 @@ public class ChatOverlay extends Table {
                 });
             }).size(48).top().pad(8);
 
-            // Content Column
             entry.table(card -> {
                 card.top().left();
                 Label label = new Label("...");
@@ -585,41 +604,64 @@ public class ChatOverlay extends Table {
                     String content = msg.content.trim();
 
                     if (PlayerConnectLink.isValid(content)) {
-                        c.add(content).wrap().color(Color.lightGray).left().growX().padTop(2);
+                        c.add(content).wrap().color(Color.lightGray).left().growX();
                         c.row();
                         renderPlayerConnectRoom(c, content);
-                    } else {
-                        int schematicBasePosition = content.indexOf(Vars.schematicBaseStart);
+                        return;
+                    }
 
-                        if (schematicBasePosition != -1) {
-                            int endPosition = content.indexOf(" ", schematicBasePosition) + 1;
+                    int schematicBasePosition = content.indexOf(Vars.schematicBaseStart);
 
-                            if (endPosition == 0) {
-                                endPosition = content.length();
-                            }
+                    if (schematicBasePosition != -1) {
+                        int endPosition = content.indexOf(" ", schematicBasePosition) + 1;
 
-                            String prev = content.substring(0, schematicBasePosition);
+                        if (endPosition == 0) {
+                            endPosition = content.length();
+                        }
 
-                            c.add(prev).wrap().color(Color.lightGray).left().growX().padTop(2);
-                            String schematicBase64 = content.substring(schematicBasePosition, endPosition);
+                        String prev = content.substring(0, schematicBasePosition);
 
-                            try {
-                                var schematic = Schematics.readBase64(schematicBase64);
-                                c.row();
-                                renderSchematic(card, schematic);
-                                c.row();
-                                String after = content.substring(endPosition);
-                                c.add(after).wrap().color(Color.lightGray).left().growX().padTop(2);
-                            } catch (Exception e) {
-                                c.clear();
-                                c.add(content).wrap().color(Color.lightGray).left().growX().padTop(2);
-                            }
-                        } else {
-                            c.add(content).wrap().color(Color.lightGray).left().growX().padTop(2);
+                        c.add(prev).wrap().color(Color.lightGray).left().growX();
+                        String schematicBase64 = content.substring(schematicBasePosition, endPosition);
+
+                        try {
+                            var schematic = Schematics.readBase64(schematicBase64);
+                            c.row();
+                            renderSchematic(card, schematic);
+                            c.row();
+                            String after = content.substring(endPosition);
+                            c.add(after).wrap().color(Color.lightGray).left().growX();
+                        } catch (Exception e) {
+                            c.clear();
+                            c.add(content).wrap().color(Color.lightGray).left().growX();
+                        }
+
+                        return;
+                    }
+
+                    Matcher matcher = MINDUSTRY_TOOL_LINK_PATTERN.matcher(content);
+
+                    if (matcher.find()) {
+                        String url = matcher.group(0);
+                        String contentType = matcher.group(1);
+                        String id = matcher.group(2);
+
+                        if (contentType.equals("maps")) {
+                            renderMap(c, id, url);
+                            c.table().growX();
+                            return;
+                        }
+
+                        if (contentType.equals("schematics")) {
+                            renderSchematic(c, id, url);
+                            c.table().growX();
+                            return;
                         }
                     }
+
+                    c.add(content).wrap().color(Color.lightGray).left().growX();
                 })
-                        .top().left().growX();
+                        .top().left().growX().padTop(6);
 
                 card.clicked(() -> {
                     Core.app.setClipboardText(msg.content);
@@ -629,6 +671,66 @@ public class ChatOverlay extends Table {
 
             messageTable.add(entry).growX().padBottom(4).row();
         }
+    }
+
+    private void renderSchematic(Table table, String id, String url) {
+        table.table(Tex.pane, preview -> {
+            preview.top().left().margin(0f);
+
+            preview.table(buttons -> {
+                buttons.center().defaults().size(PREVIEW_BUTTON_SIZE);
+
+                buttons.button(Icon.copy, Styles.emptyi, () -> SchematicDialog.handleCopySchematic(id))
+                        .pad(2);
+
+                buttons.button(Icon.download, Styles.emptyi, () -> SchematicDialog
+                        .handleDownloadSchematic(id))
+                        .pad(2);
+
+                buttons.button(Icon.info, Styles.emptyi,
+                        () -> SchematicService.findSchematicById(id)
+                                .thenAccept(schem -> Core.app.post(() -> schematicInfoDialog.show(schem))))
+                        .tooltip("@info.title");
+
+                buttons.button(Icon.link, Styles.emptyi, () -> Core.app.openURI(url))
+                        .pad(2);
+            }).growX().height(PREVIEW_BUTTON_SIZE);
+
+            preview.row();
+
+            preview.stack(new Table(t -> t.add(new mindustrytool.features.browser.schematic.SchematicImage(id))))
+                    .top()
+                    .left();
+        }).style(Styles.flati).width(TARGET_WIDTH).height(CARD_HEIGHT).top()
+                .left();
+
+    }
+
+    private void renderMap(Table table, String id, String url) {
+        table.table(Tex.pane, preview -> {
+            preview.top().left().margin(0f);
+
+            preview.table(buttons -> {
+                buttons.center().defaults().size(PREVIEW_BUTTON_SIZE);
+
+                buttons.button(Icon.download, Styles.emptyi, () -> MapDialog.handleDownloadMap(id))
+                        .pad(2);
+
+                buttons.button(Icon.info, Styles.emptyi,
+                        () -> MapService.findMapById(id)
+                                .thenAccept(m -> Core.app.post(() -> mapInfoDialog.show(m))))
+                        .tooltip("@info.title");
+
+                buttons.button(Icon.link, Styles.emptyi, () -> Core.app.openURI(url))
+                        .pad(2);
+            }).growX().height(PREVIEW_BUTTON_SIZE);
+
+            preview.row();
+
+            preview.stack(new Table(t -> t.add(new MapImage(id)))).top().left();
+        }).style(Styles.flati).width(TARGET_WIDTH).height(CARD_HEIGHT)
+                .top()
+                .left();
     }
 
     private void rebuildUserList(ChatUser[] users) {

--- a/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
+++ b/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
@@ -9,6 +9,7 @@ import arc.scene.ui.Dialog;
 import arc.scene.ui.Label;
 import arc.scene.ui.Slider;
 import arc.scene.ui.layout.Table;
+import mindustry.Vars;
 import mindustry.game.EventType.Trigger;
 import mindustry.gen.Groups;
 import mindustry.gen.Icon;
@@ -75,7 +76,7 @@ public class HealthBarVisualizer implements Feature {
     }
 
     public void draw() {
-        if (!enabled || !state.isGame()) {
+        if (!enabled || !state.isGame() || Vars.ui.hudfrag == null || !Vars.ui.hudfrag.shown) {
             return;
         }
 

--- a/src/mindustrytool/features/display/pathfinding/PathfindingDisplay.java
+++ b/src/mindustrytool/features/display/pathfinding/PathfindingDisplay.java
@@ -196,7 +196,7 @@ public class PathfindingDisplay implements Feature {
     }
 
     private void draw() {
-        if (!isEnabled || !state.isGame()) {
+        if (!isEnabled || !state.isGame() || Vars.ui.hudfrag == null || !Vars.ui.hudfrag.shown) {
             return;
         }
 

--- a/src/mindustrytool/features/display/progress/ProgressDisplay.java
+++ b/src/mindustrytool/features/display/progress/ProgressDisplay.java
@@ -60,7 +60,7 @@ public class ProgressDisplay implements Feature {
     }
 
     private void draw() {
-        if (!enabled || !Vars.state.isGame()) {
+        if (!enabled || !Vars.state.isGame() || Vars.ui.hudfrag == null || !Vars.ui.hudfrag.shown) {
             return;
         }
 

--- a/src/mindustrytool/features/display/quickaccess/QuickAccessHud.java
+++ b/src/mindustrytool/features/display/quickaccess/QuickAccessHud.java
@@ -190,6 +190,8 @@ public class QuickAccessHud extends Table implements Feature {
         currentPopupFeature = f;
 
         Table popup = new Table();
+
+        popup.visible(() -> Vars.ui.hudfrag != null && Vars.ui.hudfrag.shown);
         popup.background(Styles.black6);
         popup.touchable = Touchable.enabled;
 

--- a/src/mindustrytool/features/display/range/RangeDisplay.java
+++ b/src/mindustrytool/features/display/range/RangeDisplay.java
@@ -182,7 +182,7 @@ public class RangeDisplay implements Feature {
     }
 
     private void draw() {
-        if (!enabled || !Vars.state.isGame()) {
+        if (!enabled || !Vars.state.isGame() || Vars.ui.hudfrag == null || !Vars.ui.hudfrag.shown) {
             return;
         }
 

--- a/src/mindustrytool/features/display/teamresource/TeamResourceFeature.java
+++ b/src/mindustrytool/features/display/teamresource/TeamResourceFeature.java
@@ -88,7 +88,7 @@ public class TeamResourceFeature extends Table implements Feature {
 
         touchable = Touchable.enabled;
 
-        visible(() -> Vars.state.isGame());
+        visible(() -> Vars.state.isGame() && Vars.ui.hudfrag != null && Vars.ui.hudfrag.shown);
 
         update(() -> {
             if (!visible) {

--- a/src/mindustrytool/features/smartconveyor/SmartConveyorFeature.java
+++ b/src/mindustrytool/features/smartconveyor/SmartConveyorFeature.java
@@ -127,6 +127,7 @@ public class SmartConveyorFeature implements Feature {
     private void showMenu(Tile tile) {
         selectedTile = tile;
         currentMenu = new Table(Styles.black6);
+        currentMenu.visible(() -> Vars.ui.hudfrag != null && Vars.ui.hudfrag.shown);
         currentMenu.touchable = arc.scene.event.Touchable.enabled;
 
         currentMenu.update(() -> {

--- a/src/mindustrytool/services/MapService.java
+++ b/src/mindustrytool/services/MapService.java
@@ -10,7 +10,7 @@ import mindustrytool.dto.MapDetailData;
 
 public class MapService {
 
-    public CompletableFuture<byte[]> downloadMap(String id) {
+    public static CompletableFuture<byte[]> downloadMap(String id) {
         CompletableFuture<byte[]> future = new CompletableFuture<>();
 
         Http.get(Config.API_URL + "maps/" + id + "/data")
@@ -23,7 +23,7 @@ public class MapService {
         return future;
     }
 
-    public CompletableFuture<MapDetailData> findMapById(String id) {
+    public static CompletableFuture<MapDetailData> findMapById(String id) {
         CompletableFuture<MapDetailData> future = new CompletableFuture<>();
 
         Http.get(Config.API_URL + "maps/" + id)

--- a/src/mindustrytool/services/SchematicService.java
+++ b/src/mindustrytool/services/SchematicService.java
@@ -9,7 +9,7 @@ import mindustrytool.dto.SchematicDetailData;
 
 public class SchematicService {
 
-    public CompletableFuture<byte[]> downloadSchematic(String id) {
+    public static CompletableFuture<byte[]> downloadSchematic(String id) {
         CompletableFuture<byte[]> future = new CompletableFuture<>();
 
         Http.get(Config.API_URL + "schematics/" + id + "/data")
@@ -21,7 +21,7 @@ public class SchematicService {
         return future;
     }
 
-    public CompletableFuture<SchematicDetailData> findSchematicById(String id) {
+    public static CompletableFuture<SchematicDetailData> findSchematicById(String id) {
         CompletableFuture<SchematicDetailData> future = new CompletableFuture<>();
 
         Http.get(Config.API_URL + "schematics/" + id)


### PR DESCRIPTION
Add null checks for Vars.ui.hudfrag in multiple display features to avoid rendering when the HUD is not shown. This prevents visual artifacts and potential crashes when features attempt to draw while the game HUD is hidden.

Make MapService and SchematicService methods static to avoid unnecessary instantiation and simplify usage in dialog classes.

Add link preview support in global chat for Mindustry Tool schematic and map URLs, allowing users to directly interact with shared content without leaving the chat interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline preview cards for maps and schematics in chat with copy, download, info, and open actions.

* **Bug Fixes**
  * Prevented various HUD-related displays from rendering when the HUD is hidden or unavailable.
  * Fixed login dialog behavior to avoid duplicate cancel handling and tightened login UI text sizing.

* **Chores**
  * Bumped version to v4.35.0-v8.
  * Internal service calls refactored for simplified usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->