### PR TITLE
fix: add missing color reset tag in changelog download count line

### DIFF
--- a/src/mindustrytool/Main.java
+++ b/src/mindustrytool/Main.java
@@ -209,7 +209,7 @@ public class Main extends Mod {
                         }
 
                         changelog.append("[accent]").append(tagName).append("[]\n");
-                        changelog.append("[gold]Download count: ").append(downloadCount).append("\n");
+                        changelog.append("[gold]Download count: ").append(downloadCount).append("[]\n");
                         changelog.append(Utils.renderMarkdown(body)).append("\n\n");
                         count++;
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text formatting in release notes to properly close color tags for download count information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->