### PR TITLE
feat: add periodic server list fetching

### DIFF
--- a/src/mindustrytool/services/ServerService.java
+++ b/src/mindustrytool/services/ServerService.java
@@ -5,6 +5,7 @@ import arc.struct.Seq;
 import arc.util.Http;
 import arc.util.Log;
 import arc.util.Reflect;
+import arc.util.Timer;
 import lombok.Data;
 import mindustry.Vars;
 import mindustry.ui.dialogs.JoinDialog.Server;
@@ -19,8 +20,12 @@ public class ServerService {
         private int port, status;
     }
 
-    @SuppressWarnings("unchecked")
     public static void init() {
+        Timer.schedule(() -> fetchServers(), 0, 60 * 5);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void fetchServers() {
         Seq<Server> servers = Core.settings.getJson("servers", Seq.class, Server.class, Seq::new);
 
         servers.removeAll(server -> server.ip == null || server.ip.contains("mindustry-tool.com"));


### PR DESCRIPTION
Schedule automatic server list updates every 5 minutes using Timer.schedule. Extract server fetching logic into separate method for better organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server list is now automatically refreshed every 5 minutes to keep information current and up-to-date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->