### PR TITLE
feat(smartconveyor): add DuctBridge support to item pathfinding

### DIFF
--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -409,12 +409,13 @@ chat-translation.provider.gemini=Gemini AI
 chat-translation.provider.none=None
 
 # DeepL
-chat-translation.deepl.no-api-key=[red]No API Key[]
-chat-translation.deepl.parse-error=[red]Parse Error[]
+chat-translation.no-api-key=[red]No API Key[]
+chat-translation.parse-error=[red]Parse Error[]
 chat-translation.deepl.api-key-label=DeepL API Key:
 chat-translation.deepl.get-key-info=Get key from DeepL
-chat-translation.deepl.timeout-label=Timeout
+chat-translation.timeout-label=Timeout
 chat-translation.provider.deepl=DeepL
+chat-translation.provider.mindustry-tool=Mindustry Tool
 
 # Pretty Chat
 feature.prettychat.name = Pretty Chat

--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.37.0-v8
+version: v4.37.1-v8
 
 minGameVersion: 154
 

--- a/mod.hjson
+++ b/mod.hjson
@@ -49,7 +49,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.37.1-v8
+version: v4.38.0-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/Main.java
+++ b/src/mindustrytool/Main.java
@@ -324,6 +324,10 @@ public class Main extends Mod {
     }
 
     private static long parseCrashTime(Fi file) {
+        if (file == null) {
+            return 0;
+        }
+
         String filename = file.nameWithoutExtension();
 
         if (filename.startsWith("crash-report-")) {
@@ -369,17 +373,17 @@ public class Main extends Mod {
 
         String latestCrashKey = "latestCrash";
 
-        var savedLatest = Core.settings.getString(latestCrashKey, "");
+        var savedLatest = Core.settings.getLong(latestCrashKey, 0);
 
         if (latest == null) {
             return false;
         }
 
-        if (latest != null && latest.nameWithoutExtension().equals(savedLatest)) {
+        if (parseCrashTime(latest) == savedLatest) {
             return false;
         }
 
-        Core.settings.put(latestCrashKey, latest.nameWithoutExtension());
+        Core.settings.put(latestCrashKey, parseCrashTime(latest));
 
         showCrashDialog(latest);
 

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -29,9 +29,9 @@ import java.util.Optional;
 
 public class ChatTranslationFeature implements Feature {
     private final Seq<TranslationProvider> providers = new Seq<>();
-    private final TranslationProvider NOOP_PROVIDER = new NoopTranslationProvider();
+    private final TranslationProvider defauTranslationProvider = new MindustryToolTranslationProvider();
     private String lastError = null;
-    private TranslationProvider currentProvider = NOOP_PROVIDER;
+    private TranslationProvider currentProvider = defauTranslationProvider;
     private boolean enabled = false;
 
     @Override
@@ -73,9 +73,10 @@ public class ChatTranslationFeature implements Feature {
         Main.registerPacketPlacement(SendMessageCallPacket.class, SendTranslatedMessageCallPacket::new);
         Main.registerPacketPlacement(SendMessageCallPacket2.class, SendTranslatedMessageCallPacket2::new);
 
-        providers.add(NOOP_PROVIDER);
+        providers.add(defauTranslationProvider);
         providers.add(new GeminiTranslationProvider());
         providers.add(new DeepLTranslationProvider());
+        providers.add(new NoopTranslationProvider());
 
         providers.each(TranslationProvider::init);
 
@@ -93,7 +94,7 @@ public class ChatTranslationFeature implements Feature {
                 .thenApply(translated -> {
                     if (ChatTranslationConfig.isShowOriginal()) {
                         String locale = LanguageDialog.getDisplayName(Core.bundle.getLocale());
-                        String formated = Strings.format("[]@[]\n\n[]@[]@\n\n", message, locale, translated);
+                        String formated = Strings.format("[]@[]\n\n[gold]@[]: @\n\n", message, locale, translated);
 
                         return formated;
                     }
@@ -120,7 +121,7 @@ public class ChatTranslationFeature implements Feature {
         currentProvider = providers.find(p -> p.getId().equals(id));
 
         if (currentProvider == null) {
-            currentProvider = NOOP_PROVIDER;
+            currentProvider = defauTranslationProvider;
         }
     }
 
@@ -171,7 +172,7 @@ public class ChatTranslationFeature implements Feature {
             card.clicked(() -> {
                 if (currentProvider != prov) {
                     currentProvider = prov;
-                    var isNoop = prov.getId().equals(NOOP_PROVIDER.getId());
+                    var isNoop = prov.getId().equals(defauTranslationProvider.getId());
                     ChatTranslationConfig.setProviderId(prov.getId());
                     FeatureManager.getInstance().setEnabled(this, !isNoop);
                 }
@@ -196,7 +197,7 @@ public class ChatTranslationFeature implements Feature {
         TextButton testButton = new TextButton(Core.bundle.get("chat-translation.settings.test-button"),
                 Styles.defaultt);
         testButton.clicked(() -> {
-            if (currentProvider == NOOP_PROVIDER)
+            if (currentProvider == defauTranslationProvider)
                 return;
 
             testButton.setDisabled(true);
@@ -220,7 +221,7 @@ public class ChatTranslationFeature implements Feature {
         });
 
         root.add(testButton).size(250, 50).pad(10)
-                .disabled(b -> currentProvider == NOOP_PROVIDER
+                .disabled(b -> currentProvider == defauTranslationProvider
                         || testButton.getText().toString().equals(Core.bundle.get("chat-translation.settings.testing")))
                 .row();
         root.add(resultLabel).growX().pad(10).row();

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 public class ChatTranslationFeature implements Feature {
     private final Seq<TranslationProvider> providers = new Seq<>();
     private final TranslationProvider defaultTranslationProvider = new MindustryToolTranslationProvider();
+    private final NoopTranslationProvider noopTranslationProvider = new NoopTranslationProvider();
     private String lastError = null;
     private TranslationProvider currentProvider = defaultTranslationProvider;
     private boolean enabled = false;
@@ -73,10 +74,10 @@ public class ChatTranslationFeature implements Feature {
         Main.registerPacketPlacement(SendMessageCallPacket.class, SendTranslatedMessageCallPacket::new);
         Main.registerPacketPlacement(SendMessageCallPacket2.class, SendTranslatedMessageCallPacket2::new);
 
+        providers.add(noopTranslationProvider);
         providers.add(defaultTranslationProvider);
         providers.add(new GeminiTranslationProvider());
         providers.add(new DeepLTranslationProvider());
-        providers.add(new NoopTranslationProvider());
 
         providers.each(TranslationProvider::init);
 
@@ -172,7 +173,7 @@ public class ChatTranslationFeature implements Feature {
             card.clicked(() -> {
                 if (currentProvider != prov) {
                     currentProvider = prov;
-                    var isNoop = prov.getId().equals(defaultTranslationProvider.getId());
+                    var isNoop = prov.getId().equals(noopTranslationProvider.getId());
                     ChatTranslationConfig.setProviderId(prov.getId());
                     FeatureManager.getInstance().setEnabled(this, !isNoop);
                 }
@@ -197,7 +198,7 @@ public class ChatTranslationFeature implements Feature {
         TextButton testButton = new TextButton(Core.bundle.get("chat-translation.settings.test-button"),
                 Styles.defaultt);
         testButton.clicked(() -> {
-            if (currentProvider == defaultTranslationProvider)
+            if (currentProvider == noopTranslationProvider)
                 return;
 
             testButton.setDisabled(true);
@@ -221,7 +222,7 @@ public class ChatTranslationFeature implements Feature {
         });
 
         root.add(testButton).size(250, 50).pad(10)
-                .disabled(b -> currentProvider == defaultTranslationProvider
+                .disabled(b -> currentProvider == noopTranslationProvider
                         || testButton.getText().toString().equals(Core.bundle.get("chat-translation.settings.testing")))
                 .row();
         root.add(resultLabel).growX().pad(10).row();

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -29,9 +29,9 @@ import java.util.Optional;
 
 public class ChatTranslationFeature implements Feature {
     private final Seq<TranslationProvider> providers = new Seq<>();
-    private final TranslationProvider defauTranslationProvider = new MindustryToolTranslationProvider();
+    private final TranslationProvider defaultTranslationProvider = new MindustryToolTranslationProvider();
     private String lastError = null;
-    private TranslationProvider currentProvider = defauTranslationProvider;
+    private TranslationProvider currentProvider = defaultTranslationProvider;
     private boolean enabled = false;
 
     @Override
@@ -73,7 +73,7 @@ public class ChatTranslationFeature implements Feature {
         Main.registerPacketPlacement(SendMessageCallPacket.class, SendTranslatedMessageCallPacket::new);
         Main.registerPacketPlacement(SendMessageCallPacket2.class, SendTranslatedMessageCallPacket2::new);
 
-        providers.add(defauTranslationProvider);
+        providers.add(defaultTranslationProvider);
         providers.add(new GeminiTranslationProvider());
         providers.add(new DeepLTranslationProvider());
         providers.add(new NoopTranslationProvider());
@@ -121,7 +121,7 @@ public class ChatTranslationFeature implements Feature {
         currentProvider = providers.find(p -> p.getId().equals(id));
 
         if (currentProvider == null) {
-            currentProvider = defauTranslationProvider;
+            currentProvider = defaultTranslationProvider;
         }
     }
 
@@ -172,7 +172,7 @@ public class ChatTranslationFeature implements Feature {
             card.clicked(() -> {
                 if (currentProvider != prov) {
                     currentProvider = prov;
-                    var isNoop = prov.getId().equals(defauTranslationProvider.getId());
+                    var isNoop = prov.getId().equals(defaultTranslationProvider.getId());
                     ChatTranslationConfig.setProviderId(prov.getId());
                     FeatureManager.getInstance().setEnabled(this, !isNoop);
                 }
@@ -197,7 +197,7 @@ public class ChatTranslationFeature implements Feature {
         TextButton testButton = new TextButton(Core.bundle.get("chat-translation.settings.test-button"),
                 Styles.defaultt);
         testButton.clicked(() -> {
-            if (currentProvider == defauTranslationProvider)
+            if (currentProvider == defaultTranslationProvider)
                 return;
 
             testButton.setDisabled(true);
@@ -221,7 +221,7 @@ public class ChatTranslationFeature implements Feature {
         });
 
         root.add(testButton).size(250, 50).pad(10)
-                .disabled(b -> currentProvider == defauTranslationProvider
+                .disabled(b -> currentProvider == defaultTranslationProvider
                         || testButton.getText().toString().equals(Core.bundle.get("chat-translation.settings.testing")))
                 .row();
         root.add(resultLabel).growX().pad(10).row();

--- a/src/mindustrytool/features/chat/translation/MindustryToolTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/MindustryToolTranslationProvider.java
@@ -1,0 +1,113 @@
+package mindustrytool.features.chat.translation;
+
+import arc.Core;
+import arc.util.Http;
+import arc.util.Http.HttpStatusException;
+import lombok.Data;
+import mindustrytool.Config;
+import mindustrytool.Utils;
+import arc.scene.ui.layout.Table;
+import arc.scene.ui.Slider;
+
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+public class MindustryToolTranslationProvider implements TranslationProvider {
+
+    private int getTimeout() {
+        return Core.settings.getInt(ChatTranslationConfig.DEEPL_TIMEOUT, 10);
+    }
+
+    private void setTimeout(int timeout) {
+        Core.settings.put(ChatTranslationConfig.DEEPL_TIMEOUT, timeout);
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public CompletableFuture<String> translate(String message) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        String locale = Core.bundle.getLocale().getLanguage();
+
+        if (locale == null || locale.isEmpty()) {
+            future.completeExceptionally(
+                    new IllegalArgumentException("Invalid locale: " + Core.bundle.getLocale().getDisplayName()));
+            return future;
+        }
+
+        try {
+            HashMap<String, Object> body = new HashMap<>();
+
+            body.put("q", message);
+            body.put("source", "auto");
+            body.put("target", locale);
+
+            Http.post(Config.API_v4_URL + "/libre", Utils.toJson(body))
+                    .header("Content-Type", "application/json")
+                    .timeout(getTimeout() * 1000)
+                    .error(e -> {
+                        if (e instanceof HttpStatusException httpStatusException) {
+                            future.completeExceptionally(new RuntimeException(
+                                    Core.bundle.get("chat-translation.error.prefix")
+                                            + httpStatusException.response.getResultAsString()));
+                            return;
+                        }
+                        future.completeExceptionally(new RuntimeException(
+                                Core.bundle.get("chat-translation.error.prefix") + e.getMessage()));
+                    })
+                    .submit(res -> {
+                        String jsonString = res.getResultAsString();
+                        try {
+                            Response response = Utils.fromJson(Response.class, jsonString);
+                            future.complete(response.getTranslatedText());
+                        } catch (Exception e) {
+                            future.completeExceptionally(
+                                    new RuntimeException(Core.bundle.get("chat-translation.deepl.parse-error"), e));
+                        }
+                    });
+
+        } catch (Exception e) {
+            future.completeExceptionally(new RuntimeException("DeepL translation error", e));
+        }
+
+        return future;
+    }
+
+    @Override
+    public Table settings() {
+        Table table = new Table();
+
+        table.add(Core.bundle.get("chat-translation.timeout-label") + ": " + getTimeout() + "s").left()
+                .padTop(10)
+                .update(l -> l
+                        .setText(Core.bundle.get("chat-translation.timeout-label") + ": " + getTimeout() + "s"))
+                .row();
+
+        Slider slider = new Slider(2, 20, 1, false);
+        slider.setValue(getTimeout());
+        slider.moved(val -> {
+            setTimeout((int) val);
+        });
+        table.add(slider).growX().row();
+
+        return table;
+    }
+
+    @Override
+    public String getName() {
+        return Core.bundle.get("chat-translation.provider.mindustry-tool");
+    }
+
+    @Override
+    public String getId() {
+        return "mindustrytool";
+    }
+
+    @Data
+    private static class Response {
+        private String translatedText;
+    }
+}

--- a/src/mindustrytool/features/display/progress/ProgressDisplay.java
+++ b/src/mindustrytool/features/display/progress/ProgressDisplay.java
@@ -82,11 +82,14 @@ public class ProgressDisplay implements Feature {
         float fraction = 0f;
         float remainingTime = 0f;
 
+
+        var scale = build.timeScale();
+
         if (build instanceof UnitFactory.UnitFactoryBuild b) {
             UnitFactory block = (UnitFactory) b.block;
             if (b.currentPlan != -1 && b.currentPlan < block.plans.size) {
                 float totalTime = block.plans.get(b.currentPlan).time;
-                fraction = b.progress / totalTime;
+                fraction = b.progress / totalTime / scale;
                 remainingTime = (totalTime - b.progress) / 60f;
             }
         } else if (build instanceof Reconstructor.ReconstructorBuild b) {
@@ -107,7 +110,7 @@ public class ProgressDisplay implements Feature {
         fraction = Mathf.clamp(fraction, 0f, 1f);
 
         if (fraction > 0.01f) {
-            drawBar(build.x, build.y, build.block.size * Vars.tilesize, fraction, build.team.color, remainingTime);
+            drawBar(build.x, build.y, build.block.size * Vars.tilesize, fraction, build.team.color, remainingTime / scale);
         }
     }
 

--- a/src/mindustrytool/features/settings/FeatureSettingDialog.java
+++ b/src/mindustrytool/features/settings/FeatureSettingDialog.java
@@ -14,12 +14,14 @@ import arc.scene.ui.Dialog;
 import arc.scene.ui.layout.Scl;
 import arc.scene.ui.layout.Table;
 import arc.struct.Seq;
+import arc.util.Align;
 import arc.util.Log;
 import arc.util.Scaling;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import mindustry.Vars;
 import mindustry.gen.Icon;
+import mindustry.gen.Iconc;
 import mindustry.gen.Tex;
 import mindustry.ui.Styles;
 import mindustry.ui.dialogs.BaseDialog;
@@ -155,6 +157,11 @@ public class FeatureSettingDialog extends BaseDialog {
                     if (++i % cols == 0) {
                         table.row();
                     }
+                }
+
+                buildIconDialog(table, cardWidth);
+                if (++i % cols == 0) {
+                    table.row();
                 }
 
                 table.row();
@@ -342,6 +349,83 @@ public class FeatureSettingDialog extends BaseDialog {
                     .color(enabled ? Color.green : Color.red)
                     .left();
         }).top().left().grow();
+    }
+
+    private void buildIconDialog(Table parent, float cardWidth) {
+        parent.table(Tex.button, card -> {
+            card.top().left();
+
+            card.table(c -> {
+                c.top().left().margin(12);
+
+                c.table(header -> {
+                    header.left();
+                    header.add("Icon").style(Styles.defaultLabel).color(Color.white).growX().left();
+                }).growX().row();
+
+                c.add().growY().row();
+                c.add().growX();
+
+                c.button(Icon.linkSmall, () -> {
+                    var dialog = new BaseDialog("Icon");
+
+                    dialog.addCloseButton();
+                    dialog.closeOnBack();
+
+                    int width = 400;
+                    int cols = (int) (Core.graphics.getWidth() * 0.9 / (width + 20));
+
+                    var declaredFields = Iconc.class.getDeclaredFields();
+
+                    int col = 0;
+                    var containers = new Table();
+
+                    for (var field : declaredFields) {
+
+                        try {
+                            field.setAccessible(true);
+
+                            var icon = field.get(null);
+
+                            if (icon == Iconc.all) {
+                                continue;
+                            }
+
+                            if (icon instanceof String || icon instanceof Character) {
+                                containers.button(String.valueOf(icon) + " " + field.getName(), () -> {
+                                    Core.app.setClipboardText(String.valueOf(icon));
+                                })
+                                        .width(width)
+                                        .scaling(Scaling.fill)
+                                        .growX()
+                                        .padRight(8)
+                                        .padBottom(8)
+                                        .labelAlign(Align.left)
+                                        .top()
+                                        .left()
+                                        .get();
+
+                                if (++col % cols == 0) {
+                                    containers.row();
+                                }
+                            }
+                        } catch (Exception e) {
+                            Log.err(e);
+                        }
+
+                    }
+
+                    dialog.cont.pane(containers).scrollX(false);
+
+                    dialog.show();
+                });
+
+            }).grow();
+
+        })
+                .growX()
+                .minWidth(cardWidth)
+                .height(180f).pad(10f);
     }
 
     private UiTree getUiTree(Element element) {

--- a/src/mindustrytool/features/settings/FeatureSettingDialog.java
+++ b/src/mindustrytool/features/settings/FeatureSettingDialog.java
@@ -374,6 +374,9 @@ public class FeatureSettingDialog extends BaseDialog {
 
                     int width = 400;
                     int cols = (int) (Core.graphics.getWidth() * 0.9 / (width + 20));
+                    String[] filter = { "" };
+
+                    dialog.cont.field(filter[0], Styles.defaultField, (t) -> filter[0] = t).growX().row();
 
                     var declaredFields = Iconc.class.getDeclaredFields();
 
@@ -402,6 +405,8 @@ public class FeatureSettingDialog extends BaseDialog {
                                         .padBottom(8)
                                         .labelAlign(Align.left)
                                         .top()
+                                        .visible(() -> field.getName().toLowerCase().contains(filter[0]
+                                                .toLowerCase()))
                                         .left()
                                         .get();
 

--- a/src/mindustrytool/features/smartconveyor/SmartConveyorFeature.java
+++ b/src/mindustrytool/features/smartconveyor/SmartConveyorFeature.java
@@ -31,6 +31,7 @@ import mindustry.world.blocks.distribution.OverflowGate;
 import mindustry.world.blocks.distribution.Router;
 import mindustry.world.blocks.distribution.Sorter;
 import mindustry.world.blocks.distribution.StackConveyor;
+import mindustry.world.blocks.distribution.DuctBridge.DuctBridgeBuild;
 import mindustrytool.features.Feature;
 import mindustrytool.features.FeatureMetadata;
 
@@ -207,8 +208,14 @@ public class SmartConveyorFeature implements Feature {
                     }
                 }
 
-            } else if (block instanceof Sorter || block instanceof Router || block instanceof OverflowGate ||
-                    block instanceof DuctRouter || block instanceof OverflowDuct || block instanceof Junction) {
+            } else if (build instanceof DuctBridgeBuild ductBridge) {
+                var linked = ductBridge.findLink();
+
+                if (linked != null) {
+                    checkAndAdd(queue, visited, linked);
+                }
+            } else if (block instanceof Sorter || block instanceof Router || block instanceof OverflowGate
+                    || block instanceof DuctRouter || block instanceof OverflowDuct || block instanceof Junction) {
                 for (int i = 0; i < 4; i++) {
                     checkAndAdd(queue, visited, current.nearby(i).build);
                 }


### PR DESCRIPTION
Extend the smart conveyor's pathfinding logic to include DuctBridge blocks. When encountering a DuctBridgeBuild, the feature now checks its linked bridge to continue tracing the item path, ensuring complete network traversal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in MindustryTool translation provider set as default with configurable timeout and improved translated-message formatting.
  * Icon picker dialog added to settings for easy icon selection and copy.
  * Progress display now respects build time scaling for more accurate remaining-time visuals.

* **Bug Fixes**
  * Improved conveyor/bridge upgrade traversal to handle linked duct-bridge tiles.

* **Localization & Configuration**
  * Consolidated translation keys, added provider entry, and expanded feature descriptions.

* **Chores**
  * Bumped mod version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->