### PR TITLE
fix: stop playing random sound on music config save

### DIFF
--- a/src/mindustrytool/features/music/MusicFeature.java
+++ b/src/mindustrytool/features/music/MusicFeature.java
@@ -67,8 +67,6 @@ public class MusicFeature implements Feature {
         MusicConfig.saveBossPaths(MusicConfig.getBossPaths());
         MusicConfig.saveDarkPaths(MusicConfig.getDarkPaths());
         MusicConfig.saveAmbientPaths(MusicConfig.getAmbientPaths());
-
-        Vars.control.sound.playRandom();
     }
 
     private void loadType(Seq<String> paths, Seq<Music> masterList, Seq<Music> original) {

--- a/src/mindustrytool/features/music/MusicSettingsDialog.java
+++ b/src/mindustrytool/features/music/MusicSettingsDialog.java
@@ -85,6 +85,7 @@ public class MusicSettingsDialog extends BaseDialog {
                     }
 
                     feature.loadCustomMusic();
+                    Vars.control.sound.playRandom();
                     Core.app.post(() -> rebuild());
                 }, "ogg", "mp3");
             }).size(btnSize).padRight(5).tooltip(Core.bundle.get("music.tooltip.add", "Add custom music"));
@@ -97,6 +98,7 @@ public class MusicSettingsDialog extends BaseDialog {
                 });
                 feature.loadCustomMusic();
                 rebuild();
+                Vars.control.sound.playRandom();
             }).size(btnSize).tooltip(Core.bundle.get("music.tooltip.remove-original", "Remove all original sounds"));
         }).growX().row();
 


### PR DESCRIPTION
The sound effect was being triggered unintentionally when saving music configuration changes. This was likely a leftover debug call that should not be part of the save routine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio feedback now plays when loading custom music and removing original sounds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->