### PR TITLE
feat(chat): add multi-channel support and message pagination

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.46.3-v8
+version: v4.47.0-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/chat/global/ChatFeature.java
+++ b/src/mindustrytool/features/chat/global/ChatFeature.java
@@ -63,6 +63,8 @@ public class ChatFeature implements Feature {
     @Override
     public void onEnable() {
         overlay = new ChatOverlay();
+
+        ChatService.getInstance().disconnectStream();
         ChatService.getInstance().connectStream();
 
         if (Vars.ui.menuGroup != null) {

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -16,7 +16,9 @@ import arc.scene.ui.layout.Cell;
 import arc.scene.ui.layout.Scl;
 import arc.scene.ui.layout.Stack;
 import arc.scene.ui.layout.Table;
+import arc.struct.ObjectMap;
 import arc.struct.Seq;
+import mindustrytool.features.chat.global.dto.ChannelDto;
 import arc.util.Align;
 import arc.util.Log;
 import arc.util.Scaling;
@@ -77,7 +79,13 @@ public class ChatOverlay extends Table {
     private static final float PREVIEW_BUTTON_SIZE = 50f;
     private static final float CARD_HEIGHT = 330f;
 
-    private Seq<ChatMessage> messages = new Seq<>();
+    private ObjectMap<String, Seq<ChatMessage>> messagesByChannel = new ObjectMap<>();
+    private arc.struct.ObjectSet<String> fullyLoadedChannels = new arc.struct.ObjectSet<>();
+    private ObjectMap<String, Integer> unreadByChannel = new ObjectMap<>();
+    private Seq<ChannelDto> channels = new Seq<>();
+    private String currentChannelId = null;
+    private Table channelListTable;
+
     private Table messageTable;
     private Table userListTable;
     private ScrollPane scrollPane;
@@ -87,6 +95,7 @@ public class ChatOverlay extends Table {
     private TextButton sendButton;
 
     private State<Boolean> isSending = new State<>(false);
+    private boolean isLoadingMessages = false;
 
     private Table container;
 
@@ -266,10 +275,10 @@ public class ChatOverlay extends Table {
             container.add(buttonTable).grow();
         } else {
             container.background(Styles.black8);
-            float width = Core.graphics.getWidth() / Scl.scl() * 0.7f * widthScale;
-            float height = Core.graphics.getHeight() / Scl.scl() * 0.7f * scale;
+            float width = Core.graphics.getWidth() / Scl.scl() * 0.9f * widthScale;
+            float height = Core.graphics.getHeight() / Scl.scl() * 0.9f * scale;
 
-            containerCell.size(Math.min(width, 1400f * widthScale), Math.min(height, 900f * scale));
+            containerCell.size(Math.min(width, 1900f * widthScale), Math.min(height, 1300f * scale));
 
             // Header
             Table header = new Table();
@@ -319,9 +328,8 @@ public class ChatOverlay extends Table {
 
             // Minimize button
             header.button(Icon.refresh, Styles.clearNonei, () -> {
-                messages.clear();
-                ChatService.getInstance().disconnectStream();
-                ChatService.getInstance().connectStream();
+                messagesByChannel.clear();
+                fullyLoadedChannels.clear();
             }).size(40 * scale).padRight(4 * scale);
             header.button(Icon.down, Styles.clearNonei, this::collapse).size(40 * scale).padRight(4 * scale);
 
@@ -329,6 +337,18 @@ public class ChatOverlay extends Table {
 
             // Main Content Area
             Table mainContent = new Table();
+
+            // Left Side - Channels
+            Table leftSide = new Table();
+            leftSide.top().background(Styles.black5);
+            channelListTable = new Table();
+            channelListTable.top().left();
+            ScrollPane channelScroll = new ScrollPane(channelListTable, Styles.noBarPane);
+            channelScroll.setScrollingDisabled(true, false);
+            leftSide.add(channelScroll).grow();
+
+            mainContent.add(leftSide).width(160f * scale).growY();
+            mainContent.image(Tex.whiteui).width(1f * scale).color(Color.darkGray).fillY();
 
             // Messages
             messageTable = new Table();
@@ -338,11 +358,21 @@ public class ChatOverlay extends Table {
             scrollPane.setScrollingDisabled(true, false);
             scrollPane.setFadeScrollBars(false);
             scrollPane.visible(() -> ChatService.getInstance().isConnected());
+            scrollPane.scrolled(amount -> {
+                if (scrollPane.getScrollY() < 100 && !isLoadingMessages && currentChannelId != null
+                        && !fullyLoadedChannels.contains(currentChannelId)) {
+                    Seq<ChatMessage> msgs = messagesByChannel.get(currentChannelId);
+                    if (msgs != null && !msgs.isEmpty()) {
+                        loadMoreMessages(currentChannelId, msgs.first().id);
+                    }
+                }
+            });
 
             loadingTable = new Table();
 
             loadingTable.add("@loading").style(Styles.defaultLabel).color(Color.gray)
-                    .visible(() -> !ChatService.getInstance().isConnected()).get().setFontScale(scale);
+                    .visible(() -> !ChatService.getInstance().isConnected() || isLoadingMessages).get()
+                    .setFontScale(scale);
 
             Stack stack = new Stack();
             stack.add(loadingTable);
@@ -399,8 +429,24 @@ public class ChatOverlay extends Table {
 
             // Fetch users
             Timer.schedule(() -> {
-                ChatService.getInstance().getChatUsers(this::rebuildUserList, e -> Log.err("Failed to fetch users", e));
+                if (currentChannelId != null) {
+                    ChatService.getInstance().getChatUsers(currentChannelId, this::rebuildUserList,
+                            e -> Log.err("Failed to fetch users", e));
+                }
             }, 0.25f);
+
+            if (channels.isEmpty()) {
+                ChatService.getInstance().getChannels(chans -> {
+                    channels.clear();
+                    channels.addAll(chans);
+                    if (channels.size > 0 && currentChannelId == null) {
+                        switchChannel(channels.get(0).id);
+                    }
+                    rebuildChannelList();
+                }, e -> Log.err("Failed to fetch channels", e));
+            } else {
+                rebuildChannelList();
+            }
 
             buildInputTable(inputTable);
 
@@ -428,6 +474,126 @@ public class ChatOverlay extends Table {
 
         keepInScreen();
 
+    }
+
+    private void rebuildChannelList() {
+        if (channelListTable == null)
+            return;
+        channelListTable.clear();
+        channelListTable.top().left();
+
+        float scale = ChatConfig.scale();
+
+        for (ChannelDto channel : channels) {
+            boolean isSelected = channel.id.equals(currentChannelId);
+            TextButton btn = new TextButton("# " + channel.name, isSelected ? Styles.togglet : Styles.cleart);
+            btn.getLabel().setAlignment(Align.left);
+            btn.getLabel().setFontScale(scale);
+            if (isSelected) {
+                btn.setChecked(true);
+            }
+
+            int unread = unreadByChannel.get(channel.id, 0);
+            if (unread > 0 && !isSelected) {
+                btn.getLabel().setColor(Color.white);
+                btn.setText("# " + channel.name + " (" + (unread > 99 ? "99+" : unread) + ")");
+            } else {
+                btn.getLabel().setColor(Color.lightGray);
+            }
+
+            btn.clicked(() -> {
+                if (!isSelected) {
+                    switchChannel(channel.id);
+                }
+            });
+
+            channelListTable.add(btn).growX().height(40 * scale).pad(2 * scale).row();
+        }
+    }
+
+    private void switchChannel(String channelId) {
+        currentChannelId = channelId;
+        unreadByChannel.put(channelId, 0);
+        updateBadge();
+        rebuildChannelList();
+
+        if (messageTable != null) {
+            messageTable.clear();
+        }
+
+        if (!messagesByChannel.containsKey(channelId) || messagesByChannel.get(channelId).isEmpty()) {
+            isLoadingMessages = true;
+            ChatService.getInstance().fetchMessages(channelId, null, msgs -> {
+                if (channelId.equals(currentChannelId)) {
+                    isLoadingMessages = false;
+                }
+                Seq<ChatMessage> seq = new Seq<>(msgs);
+                messagesByChannel.put(channelId, seq.reverse());
+                if (channelId.equals(currentChannelId)) {
+                    rebuildMessages(messageTable);
+                    if (scrollPane != null) {
+                        Core.app.post(() -> scrollPane.setScrollY(scrollPane.getMaxY()));
+                    }
+                }
+            }, e -> {
+                if (channelId.equals(currentChannelId)) {
+                    isLoadingMessages = false;
+                }
+                Log.err("Failed to fetch messages for channel", e);
+            });
+        } else {
+            isLoadingMessages = false;
+            rebuildMessages(messageTable);
+            if (scrollPane != null) {
+                Core.app.post(() -> scrollPane.setScrollY(scrollPane.getMaxY()));
+            }
+        }
+
+        ChatService.getInstance().getChatUsers(channelId, this::rebuildUserList,
+                e -> Log.err("Failed to fetch users", e));
+    }
+
+    private void loadMoreMessages(String channelId, String cursor) {
+        if (isLoadingMessages)
+            return;
+        isLoadingMessages = true;
+        ChatService.getInstance().fetchMessages(channelId, cursor, msgs -> {
+            if (channelId.equals(currentChannelId)) {
+                isLoadingMessages = false;
+            }
+            if (msgs.length > 0) {
+                Seq<ChatMessage> seq = messagesByChannel.get(channelId);
+                if (seq == null) {
+                    seq = new Seq<>();
+                    messagesByChannel.put(channelId, seq);
+                }
+
+                // Keep track of old scroll Y
+                float oldMaxY = scrollPane != null ? scrollPane.getMaxY() : 0;
+                float oldScrollY = scrollPane != null ? scrollPane.getScrollY() : 0;
+
+                Seq<ChatMessage> oldMsgs = new Seq<>(msgs);
+                oldMsgs.reverse().addAll(seq);
+                messagesByChannel.put(channelId, oldMsgs);
+
+                if (channelId.equals(currentChannelId)) {
+                    rebuildMessages(messageTable);
+                    if (scrollPane != null) {
+                        Core.app.post(() -> {
+                            float newMaxY = scrollPane.getMaxY();
+                            scrollPane.setScrollY(oldScrollY + (newMaxY - oldMaxY));
+                        });
+                    }
+                }
+            } else {
+                fullyLoadedChannels.add(channelId);
+            }
+        }, e -> {
+            if (channelId.equals(currentChannelId)) {
+                isLoadingMessages = false;
+            }
+            Log.err("Failed to fetch more messages for channel", e);
+        });
     }
 
     private void buildInputTable(Table inputTable) {
@@ -517,38 +683,55 @@ public class ChatOverlay extends Table {
     }
 
     public synchronized void addMessages(ChatMessage... newMessages) {
-        int addedCount = 0;
+        int totalAddedCount = 0;
+        boolean currentChannelUpdated = false;
 
         for (ChatMessage msg : newMessages) {
-            if (messages.contains(m -> m.id.equals(msg.id))) {
+            String cId = msg.channelId;
+            if (cId == null)
+                continue;
+
+            if (!messagesByChannel.containsKey(cId)) {
+                messagesByChannel.put(cId, new Seq<>());
+            }
+            Seq<ChatMessage> channelMsgs = messagesByChannel.get(cId);
+
+            if (channelMsgs.contains(m -> m.id.equals(msg.id))) {
                 continue;
             }
 
-            messages.add(msg);
+            channelMsgs.add(msg);
+
+            if (cId.equals(currentChannelId)) {
+                currentChannelUpdated = true;
+            }
+
+            if (channelMsgs.size > 1000) {
+                channelMsgs.remove(0);
+            }
 
             try {
-                if (ChatConfig.collapsed() && ChatConfig.lastRead().isBefore(Instant.parse(msg.createdAt))) {
-                    addedCount++;
+                if ((ChatConfig.collapsed() || !cId.equals(currentChannelId))
+                        && ChatConfig.lastRead().isBefore(Instant.parse(msg.createdAt))) {
+                    unreadByChannel.put(cId, unreadByChannel.get(cId, 0) + 1);
+                    totalAddedCount++;
                 }
             } catch (Exception e) {
                 Log.err(e);
             }
         }
 
-        if (ChatConfig.collapsed() && addedCount > 0) {
-            unreadCount += addedCount;
+        if (totalAddedCount > 0) {
+            unreadCount += totalAddedCount;
             updateBadge();
-        } else {
+            Core.app.post(() -> rebuildChannelList());
+        }
+
+        if (!ChatConfig.collapsed() && currentChannelId != null && currentChannelUpdated) {
             ChatConfig.lastRead(Instant.now());
         }
 
-        if (messages.size > 1000) {
-            messages.remove(0);
-        }
-
-        if (messageTable != null && !ChatConfig.collapsed()) {
-            // Scroll to bottom
-
+        if (messageTable != null && !ChatConfig.collapsed() && currentChannelUpdated) {
             Core.app.post(() -> {
                 rebuildMessages(messageTable);
             });
@@ -567,9 +750,23 @@ public class ChatOverlay extends Table {
 
         float scale = ChatConfig.scale();
 
-        ChatConfig.lastRead(Instant.now());
+        if (currentChannelId != null) {
+            ChatConfig.lastRead(Instant.now());
+        }
 
-        for (ChatMessage msg : messages) {
+        if (currentChannelId == null && !channels.isEmpty()) {
+            currentChannelId = channels.get(0).id;
+        }
+
+        if (currentChannelId == null) {
+            return;
+        }
+
+        Seq<ChatMessage> channelMsgs = messagesByChannel.get(currentChannelId);
+        if (channelMsgs == null)
+            return;
+
+        for (ChatMessage msg : channelMsgs) {
             Table entry = new Table();
 
             entry.setBackground(null);
@@ -843,23 +1040,34 @@ public class ChatOverlay extends Table {
             return;
         }
 
-        send(() -> ChatService.getInstance().sendMessage(content).thenAccept(this::addMessages));
+        if (currentChannelId == null)
+            return;
+
+        send(() -> ChatService.getInstance().sendMessage(currentChannelId, content).thenAccept(this::addMessages));
     }
 
     private void sendSchematic() {
-        send(() -> ChatService.getInstance().sendSchematic(inputField.getText()).thenAccept(this::addMessages));
+        if (currentChannelId == null)
+            return;
+        send(() -> ChatService.getInstance().sendSchematic(currentChannelId, inputField.getText())
+                .thenAccept(this::addMessages));
     }
 
     private void handleAttachContent(String content) {
         if (content == null || content.isEmpty())
             return;
 
+        if (currentChannelId == null)
+            return;
+
         boolean isSchematic = isSchematic(content.trim());
 
         if (isSchematic) {
-            send(() -> ChatService.getInstance().sendSchematic(content).thenAccept(this::addMessages), false);
+            send(() -> ChatService.getInstance().sendSchematic(currentChannelId, content).thenAccept(this::addMessages),
+                    false);
         } else {
-            send(() -> ChatService.getInstance().sendMessage(content).thenAccept(this::addMessages), false);
+            send(() -> ChatService.getInstance().sendMessage(currentChannelId, content).thenAccept(this::addMessages),
+                    false);
         }
     }
 

--- a/src/mindustrytool/features/chat/global/ChatService.java
+++ b/src/mindustrytool/features/chat/global/ChatService.java
@@ -21,6 +21,7 @@ import mindustrytool.features.chat.global.dto.ChatMessage;
 import mindustrytool.features.chat.global.dto.ChatMessageReceive;
 import mindustrytool.features.chat.global.dto.ChatStateChange;
 import mindustrytool.features.chat.global.dto.ChatUser;
+import mindustrytool.features.chat.global.dto.ChannelDto;
 
 public class ChatService {
     private static ChatService instance;
@@ -42,7 +43,7 @@ public class ChatService {
         return isConnected.get();
     }
 
-    public void connectStream() {
+    public synchronized void connectStream() {
         if (isStreaming.get()) {
             return;
         }
@@ -55,9 +56,11 @@ public class ChatService {
                 try {
                     AuthService.getInstance().refreshTokenIfNeeded().get();
 
-                    Log.info("Connecting to chat stream...");
+                    Log.info("Connecting to chat stream");
 
-                    URL url = new URL(Config.API_v4_URL + "chats/stream");
+                    String urlStr = Config.API_v4_URL + "chats/stream";
+
+                    URL url = new URL(urlStr);
                     conn = (HttpURLConnection) url.openConnection();
                     conn.setRequestMethod("GET");
                     conn.setRequestProperty("Accept", "text/event-stream");
@@ -82,6 +85,8 @@ public class ChatService {
                     }
 
                     broadcastConnectionStatus(true);
+
+                    Log.info("Chat stream connected");
 
                     BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
                     String line;
@@ -154,11 +159,34 @@ public class ChatService {
         Log.info("Chat stream disconnected.");
     }
 
-    public CompletableFuture<ChatMessage> sendMessage(String content) {
+    public void getChannels(Cons<ChannelDto[]> onSuccess, Cons<Throwable> onError) {
+        AuthHttp.get(Config.API_v4_URL + "chats/channels")
+                .error(onError)
+                .submit(res -> {
+                    try {
+                        Json json = new Json();
+                        ChannelDto[] channels = json.fromJson(ChannelDto[].class, res.getResultAsString());
+                        if (channels == null) {
+                            Core.app.post(() -> onSuccess.get(new ChannelDto[0]));
+                        } else {
+                            Core.app.post(() -> onSuccess.get(channels));
+                        }
+                    } catch (Exception e) {
+                        Core.app.post(() -> onError.get(e));
+                    }
+                });
+    }
+
+    public CompletableFuture<ChatMessage> sendMessage(String channelId, String content) {
         CompletableFuture<ChatMessage> future = new CompletableFuture<>();
+        if (channelId == null) {
+            future.completeExceptionally(new IllegalArgumentException("Channel ID cannot be null"));
+            return future;
+        }
         try {
             Jval json = Jval.newObject();
             json.put("content", content);
+            json.put("channelId", channelId);
 
             AuthHttp.post(Config.API_v4_URL + "chats/text", json.toString())
                     .header("Content-Type", "application/json")
@@ -172,14 +200,18 @@ public class ChatService {
         }
     }
 
-    public CompletableFuture<ChatMessage> sendSchematic(String content) {
+    public CompletableFuture<ChatMessage> sendSchematic(String channelId, String content) {
         CompletableFuture<ChatMessage> future = new CompletableFuture<>();
+        if (channelId == null) {
+            future.completeExceptionally(new IllegalArgumentException("Channel ID cannot be null"));
+            return future;
+        }
         try {
             Jval json = Jval.newObject();
             json.put("content", content);
-            json.put("type", "msch");
+            json.put("channelId", channelId);
 
-            AuthHttp.post(Config.API_v4_URL + "chats/schematic", json.toString())
+            AuthHttp.post(Config.API_v4_URL + "chats/msch", json.toString())
                     .header("Content-Type", "application/json")
                     .error(future::completeExceptionally)
                     .submit(res -> future.complete(Utils.fromJson(ChatMessage.class, res.getResultAsString())));
@@ -191,8 +223,12 @@ public class ChatService {
         }
     }
 
-    public void getChatUsers(Cons<ChatUser[]> onSuccess, Cons<Throwable> onError) {
-        AuthHttp.get(Config.API_v4_URL + "chats/users")
+    public void getChatUsers(String channelId, Cons<ChatUser[]> onSuccess, Cons<Throwable> onError) {
+        if (channelId == null) {
+            onError.get(new IllegalArgumentException("Channel ID cannot be null"));
+            return;
+        }
+        AuthHttp.get(Config.API_v4_URL + "chats/users?channelId=" + channelId)
                 .error(onError)
                 .submit(res -> {
                     try {
@@ -200,9 +236,38 @@ public class ChatService {
                         ChatUser[] users = json.fromJson(ChatUser[].class, res.getResultAsString());
 
                         if (users == null) {
-                            onSuccess.get(new ChatUser[0]);
+                            Core.app.post(() -> onSuccess.get(new ChatUser[0]));
                         } else {
                             Core.app.post(() -> onSuccess.get(users));
+                        }
+                    } catch (Exception e) {
+                        Core.app.post(() -> onError.get(e));
+                    }
+                });
+    }
+
+    public void fetchMessages(String channelId, String cursor, Cons<ChatMessage[]> onSuccess, Cons<Throwable> onError) {
+        if (channelId == null) {
+            onError.get(new IllegalArgumentException("Channel ID cannot be null"));
+            return;
+        }
+
+        String url = Config.API_v4_URL + "chats?channelId=" + channelId;
+        if (cursor != null && !cursor.isEmpty()) {
+            url += "&cursor=" + cursor;
+        }
+
+        AuthHttp.get(url)
+                .error(onError)
+                .submit(res -> {
+                    try {
+                        Json json = new Json();
+                        ChatMessage[] msgs = json.fromJson(ChatMessage[].class, res.getResultAsString());
+
+                        if (msgs == null) {
+                            Core.app.post(() -> onSuccess.get(new ChatMessage[0]));
+                        } else {
+                            Core.app.post(() -> onSuccess.get(msgs));
                         }
                     } catch (Exception e) {
                         Core.app.post(() -> onError.get(e));

--- a/src/mindustrytool/features/chat/global/dto/ChannelDto.java
+++ b/src/mindustrytool/features/chat/global/dto/ChannelDto.java
@@ -1,0 +1,9 @@
+package mindustrytool.features.chat.global.dto;
+
+import lombok.Data;
+
+@Data
+public class ChannelDto {
+    public String id;
+    public String name;
+}

--- a/src/mindustrytool/features/chat/global/dto/ChatMessage.java
+++ b/src/mindustrytool/features/chat/global/dto/ChatMessage.java
@@ -7,6 +7,7 @@ public class ChatMessage {
     public String id;
     public String createdBy;
     public String createdAt;
-    public String type;
     public String content;
+    public String replyTo;
+    public String channelId;
 }


### PR DESCRIPTION
- Introduce ChannelDto and update ChatMessage to include channelId and replyTo fields
- Add channel switching UI with unread message badges
- Implement message pagination with lazy loading for each channel
- Update API endpoints to support channel-specific operations
- Improve chat overlay layout with dedicated channel list panel
- Add disconnectStream call before reconnecting to ensure clean state
- Bump mod version to v4.47.0-v8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-channel chat support with a dedicated channel list sidebar, allowing users to switch between channels seamlessly
  * Automatic message history pagination that loads additional messages when scrolling upward within conversations
  * Per-channel message tracking with individual unread counts and channel-specific user rosters

* **Bug Fixes**
  * Improved chat stream connection stability and recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->