### PR TITLE
fix(auth): increase timeout and wrap token parsing in try-catch

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.47.1-v8
+version: v4.47.2-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -154,28 +154,32 @@ public class AuthService {
                     Core.settings.remove(KEY_LOGIN_ID);
                     future.completeExceptionally(new RuntimeException("Failed to get login token", e));
                 })
-                .timeout(15000)
+                .timeout(60 * 1000)
                 .submit(res -> {
-                    Core.settings.remove(KEY_LOGIN_ID);
+                    try {
+                        Core.settings.remove(KEY_LOGIN_ID);
 
-                    Jval json = Jval.read(res.getResultAsString());
+                        Jval json = Jval.read(res.getResultAsString());
 
-                    if (json.has("accessToken") && json.has("refreshToken")) {
-                        String accessToken = json.getString("accessToken");
-                        String refreshToken = json.getString("refreshToken");
+                        if (json.has("accessToken") && json.has("refreshToken")) {
+                            String accessToken = json.getString("accessToken");
+                            String refreshToken = json.getString("refreshToken");
 
-                        saveTokens(accessToken, refreshToken);
+                            saveTokens(accessToken, refreshToken);
 
-                        sessionStore.fetch().whenComplete((v, e) -> {
-                            if (e != null) {
-                                future.completeExceptionally(e);
-                            } else {
-                                Core.app.post(() -> Events.fire(new LoginEvent()));
-                                future.complete(null);
-                            }
-                        });
-                    } else {
-                        future.completeExceptionally(new RuntimeException("Invalid response: missing tokens"));
+                            sessionStore.fetch().whenComplete((v, e) -> {
+                                if (e != null) {
+                                    future.completeExceptionally(e);
+                                } else {
+                                    Core.app.post(() -> Events.fire(new LoginEvent()));
+                                    future.complete(null);
+                                }
+                            });
+                        } else {
+                            future.completeExceptionally(new RuntimeException("Invalid response: missing tokens"));
+                        }
+                    } catch (Exception e) {
+                        future.completeExceptionally(e);
                     }
                 });
         return future;

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -217,8 +217,6 @@ public class ChatOverlay extends Table {
     private synchronized void setup() {
         setPosition(ChatConfig.x(ChatConfig.collapsed()), ChatConfig.y(ChatConfig.collapsed()));
 
-        Vars.mobile = true;
-
         container.clearChildren();
         container.touchable = Touchable.enabled;
         container.setColor(1f, 1f, 1f, ChatConfig.opacity());

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -78,12 +78,19 @@ public class ChatOverlay extends Table {
     private static final float TARGET_WIDTH = 250f;
     private static final float PREVIEW_BUTTON_SIZE = 50f;
     private static final float CARD_HEIGHT = 330f;
+    private static final String CURRENT_CHANNEL_ID_KEY = "mindustrytool-current-channel-id";
+
+    public enum MobileTab {
+        CHANNELS, MESSAGES, MEMBERS
+    }
+
+    private MobileTab currentMobileTab = MobileTab.MESSAGES;
 
     private ObjectMap<String, Seq<ChatMessage>> messagesByChannel = new ObjectMap<>();
     private arc.struct.ObjectSet<String> fullyLoadedChannels = new arc.struct.ObjectSet<>();
     private ObjectMap<String, Integer> unreadByChannel = new ObjectMap<>();
     private Seq<ChannelDto> channels = new Seq<>();
-    private String currentChannelId = null;
+    private String currentChannelId = Core.settings.getString(CURRENT_CHANNEL_ID_KEY, null);
     private Table channelListTable;
 
     private Table messageTable;
@@ -179,6 +186,13 @@ public class ChatOverlay extends Table {
             inputField.setDisabled(curr);
             buildInputTable(inputTable);
         });
+        Events.on(ChatStateChange.class, event -> {
+            var connected = event.connected;
+
+            if (connectionIndicator != null) {
+                connectionIndicator.setColor(connected ? Color.green : Color.yellow);
+            }
+        });
         Core.app.post(() -> setup());
     }
 
@@ -202,6 +216,8 @@ public class ChatOverlay extends Table {
 
     private synchronized void setup() {
         setPosition(ChatConfig.x(ChatConfig.collapsed()), ChatConfig.y(ChatConfig.collapsed()));
+
+        Vars.mobile = true;
 
         container.clearChildren();
         container.touchable = Touchable.enabled;
@@ -281,7 +297,8 @@ public class ChatOverlay extends Table {
             float width = Core.graphics.getWidth() / Scl.scl() * 0.9f * widthScale;
             float height = Core.graphics.getHeight() / Scl.scl() * 0.9f * scale;
 
-            containerCell.size(Math.min(width, 1900f * widthScale), Math.min(height, 1300f * scale));
+            float actualWidth = Math.min(width, 1900f * widthScale);
+            containerCell.size(actualWidth, Math.min(height, 1300f * scale));
 
             // Header
             Table header = new Table();
@@ -312,10 +329,6 @@ public class ChatOverlay extends Table {
                 }
             });
 
-            header.image(Icon.move).color(Color.gray).size(24 * scale).padLeft(8 * scale);
-            Label title = header.add("@chat.global-chat").style(Styles.outlineLabel).padLeft(8 * scale).get();
-            title.setFontScale(scale);
-
             connectionIndicator = new Image(Tex.whiteui) {
                 @Override
                 public void draw() {
@@ -325,110 +338,245 @@ public class ChatOverlay extends Table {
                 }
             };
             connectionIndicator.setColor(ChatService.getInstance().isConnected() ? Color.green : Color.yellow);
-            header.add(connectionIndicator).size(10 * scale).padLeft(8 * scale);
 
-            header.add().growX();
+            if (Vars.mobile) {
+                if (currentMobileTab == MobileTab.MESSAGES) {
+                    header.button(Icon.left, Styles.clearNonei, () -> {
+                        currentMobileTab = MobileTab.CHANNELS;
+                        setup();
+                    }).size(40 * scale).padLeft(4 * scale);
+                    header.image(Icon.move).color(Color.gray).size(24 * scale).padLeft(4 * scale);
 
-            // Minimize button
-            header.button(Icon.refresh, Styles.clearNonei, () -> {
-                messagesByChannel.clear();
-                fullyLoadedChannels.clear();
-            }).size(40 * scale).padRight(4 * scale);
-            header.button(Icon.down, Styles.clearNonei, this::collapse).size(40 * scale).padRight(4 * scale);
+                    String chanName = "@chat.global-chat";
+                    if (currentChannelId != null) {
+                        ChannelDto c = channels.find(ch -> ch.id.equals(currentChannelId));
+                        if (c != null)
+                            chanName = "# " + c.name;
+                    }
+                    Label title = header.add(chanName).style(Styles.outlineLabel).padLeft(8 * scale).get();
+                    title.setFontScale(scale);
+
+                    header.add(connectionIndicator).size(10 * scale).padLeft(8 * scale);
+                    header.add().growX();
+
+                    header.button(Icon.right, Styles.clearNonei, () -> {
+                        currentMobileTab = MobileTab.MEMBERS;
+                        setup();
+                    }).size(40 * scale).padRight(4 * scale);
+                    header.button(Icon.refresh, Styles.clearNonei, () -> {
+                        messagesByChannel.clear();
+                        fullyLoadedChannels.clear();
+                    }).size(40 * scale).padRight(4 * scale);
+                    header.button(Icon.cancel, Styles.clearNonei, this::collapse).size(40 * scale).padRight(4 * scale);
+                } else if (currentMobileTab == MobileTab.CHANNELS) {
+                    header.image(Icon.move).color(Color.gray).size(24 * scale).padLeft(8 * scale);
+                    Label title = header.add("@chat.channels").style(Styles.outlineLabel).padLeft(8 * scale).get();
+                    title.setFontScale(scale);
+                    header.add().growX();
+                    header.button(Icon.refresh, Styles.clearNonei, () -> {
+                        messagesByChannel.clear();
+                        fullyLoadedChannels.clear();
+                    }).size(40 * scale).padRight(4 * scale);
+                    header.button(Icon.cancel, Styles.clearNonei, this::collapse).size(40 * scale).padRight(4 * scale);
+                    header.button(Icon.right, Styles.clearNonei, () -> {
+                        currentMobileTab = MobileTab.MESSAGES;
+                        setup();
+                    }).size(40 * scale).padRight(4 * scale);
+                } else if (currentMobileTab == MobileTab.MEMBERS) {
+                    header.button(Icon.left, Styles.clearNonei, () -> {
+                        currentMobileTab = MobileTab.MESSAGES;
+                        setup();
+                    }).size(40 * scale).padLeft(4 * scale);
+                    header.image(Icon.move).color(Color.gray).size(24 * scale).padLeft(4 * scale);
+                    Label title = header.add("@chat.online-members").style(Styles.outlineLabel).padLeft(8 * scale)
+                            .get();
+                    title.setFontScale(scale);
+                    header.add().growX();
+                    header.button(Icon.refresh, Styles.clearNonei, () -> {
+                        messagesByChannel.clear();
+                        fullyLoadedChannels.clear();
+                    }).size(40 * scale).padRight(4 * scale);
+                    header.button(Icon.cancel, Styles.clearNonei, this::collapse).size(40 * scale).padRight(4 * scale);
+                }
+            } else {
+                header.image(Icon.move).color(Color.gray).size(24 * scale).padLeft(8 * scale);
+                Label title = header.add("@chat.global-chat").style(Styles.outlineLabel).padLeft(8 * scale).get();
+                title.setFontScale(scale);
+
+                header.add(connectionIndicator).size(10 * scale).padLeft(8 * scale);
+
+                header.add().growX();
+
+                // Minimize button
+                header.button(Icon.refresh, Styles.clearNonei, () -> {
+                    messagesByChannel.clear();
+                    fullyLoadedChannels.clear();
+                }).size(40 * scale).padRight(4 * scale);
+                header.button(Icon.cancel, Styles.clearNonei, this::collapse).size(40 * scale).padRight(4 * scale);
+            }
 
             container.add(header).growX().height(46 * scale).row();
 
             // Main Content Area
             Table mainContent = new Table();
 
-            // Left Side - Channels
-            Table leftSide = new Table();
-            leftSide.top().background(Styles.black5);
-            channelListTable = new Table();
-            channelListTable.top().left();
-            ScrollPane channelScroll = new ScrollPane(channelListTable, Styles.noBarPane);
-            channelScroll.setScrollingDisabled(true, false);
-            leftSide.add(channelScroll).grow();
+            if (Vars.mobile) {
+                if (currentMobileTab == MobileTab.CHANNELS) {
+                    Table leftSide = new Table();
+                    leftSide.top().background(Styles.black5);
+                    channelListTable = new Table();
+                    channelListTable.top().left();
+                    ScrollPane channelScroll = new ScrollPane(channelListTable, Styles.noBarPane);
+                    channelScroll.setScrollingDisabled(true, false);
+                    leftSide.add(channelScroll).grow();
+                    mainContent.add(leftSide).grow();
+                } else if (currentMobileTab == MobileTab.MEMBERS) {
+                    Table rightSide = new Table();
+                    rightSide.top().background(Styles.black3);
+                    userListTable = new Table();
+                    userListTable.top().left();
+                    ScrollPane userScrollPane = new ScrollPane(userListTable, Styles.noBarPane);
+                    userScrollPane.setScrollingDisabled(true, false);
+                    rightSide.add(userScrollPane).grow().row();
+                    mainContent.add(rightSide).grow();
+                } else {
+                    messageTable = new Table();
+                    messageTable.top().left();
 
-            mainContent.add(leftSide).width(160f * scale).growY();
-            mainContent.image(Tex.whiteui).width(1f * scale).color(Color.darkGray).fillY();
+                    scrollPane = new ScrollPane(messageTable, Styles.noBarPane);
+                    scrollPane.setScrollingDisabled(true, false);
+                    scrollPane.setFadeScrollBars(false);
+                    scrollPane.visible(() -> ChatService.getInstance().isConnected());
+                    scrollPane.scrolled(amount -> {
+                        if (scrollPane.getScrollY() < 100 && !isLoadingMessages && currentChannelId != null
+                                && !fullyLoadedChannels.contains(currentChannelId)) {
+                            Seq<ChatMessage> msgs = messagesByChannel.get(currentChannelId);
+                            if (msgs != null && !msgs.isEmpty()) {
+                                loadMoreMessages(currentChannelId, msgs.first().id);
+                            }
+                        }
+                    });
 
-            // Messages
-            messageTable = new Table();
-            messageTable.top().left();
+                    loadingTable = new Table();
 
-            scrollPane = new ScrollPane(messageTable, Styles.noBarPane);
-            scrollPane.setScrollingDisabled(true, false);
-            scrollPane.setFadeScrollBars(false);
-            scrollPane.visible(() -> ChatService.getInstance().isConnected());
-            scrollPane.scrolled(amount -> {
-                if (scrollPane.getScrollY() < 100 && !isLoadingMessages && currentChannelId != null
-                        && !fullyLoadedChannels.contains(currentChannelId)) {
-                    Seq<ChatMessage> msgs = messagesByChannel.get(currentChannelId);
-                    if (msgs != null && !msgs.isEmpty()) {
-                        loadMoreMessages(currentChannelId, msgs.first().id);
+                    loadingTable.add("@loading").style(Styles.defaultLabel).color(Color.gray)
+                            .visible(() -> !ChatService.getInstance().isConnected() || isLoadingMessages).get()
+                            .setFontScale(scale);
+
+                    Stack stack = new Stack();
+                    stack.add(loadingTable);
+                    stack.add(scrollPane);
+
+                    Table centerArea = new Table();
+                    centerArea.add(stack).grow().row();
+
+                    buildInputTable(inputTable);
+                    centerArea.add(inputTable).growX().bottom();
+
+                    mainContent.add(centerArea).grow().minWidth(0);
+                }
+                container.add(mainContent).grow().minWidth(0).row();
+            } else {
+                float leftWidth = Math.min(160f * scale, actualWidth * 0.25f);
+                float rightWidthExp = Math.min(280f * scale, actualWidth * 0.35f);
+                float rightWidthCol = 48f * scale;
+
+                // Left Side - Channels
+                Table leftSide = new Table();
+                leftSide.top().background(Styles.black5);
+                channelListTable = new Table();
+                channelListTable.top().left();
+                ScrollPane channelScroll = new ScrollPane(channelListTable, Styles.noBarPane);
+                channelScroll.setScrollingDisabled(true, false);
+                leftSide.add(channelScroll).grow();
+
+                mainContent.add(leftSide).width(leftWidth).growY();
+                mainContent.image(Tex.whiteui).width(1f * scale).color(Color.darkGray).fillY();
+
+                // Messages
+                messageTable = new Table();
+                messageTable.top().left();
+
+                scrollPane = new ScrollPane(messageTable, Styles.noBarPane);
+                scrollPane.setScrollingDisabled(true, false);
+                scrollPane.setFadeScrollBars(false);
+                scrollPane.visible(() -> ChatService.getInstance().isConnected());
+                scrollPane.scrolled(amount -> {
+                    if (scrollPane.getScrollY() < 100 && !isLoadingMessages && currentChannelId != null
+                            && !fullyLoadedChannels.contains(currentChannelId)) {
+                        Seq<ChatMessage> msgs = messagesByChannel.get(currentChannelId);
+                        if (msgs != null && !msgs.isEmpty()) {
+                            loadMoreMessages(currentChannelId, msgs.first().id);
+                        }
                     }
-                }
-            });
+                });
 
-            loadingTable = new Table();
+                loadingTable = new Table();
 
-            loadingTable.add("@loading").style(Styles.defaultLabel).color(Color.gray)
-                    .visible(() -> !ChatService.getInstance().isConnected() || isLoadingMessages).get()
-                    .setFontScale(scale);
+                loadingTable.add("@loading").style(Styles.defaultLabel).color(Color.gray)
+                        .visible(() -> !ChatService.getInstance().isConnected() || isLoadingMessages).get()
+                        .setFontScale(scale);
 
-            Stack stack = new Stack();
-            stack.add(loadingTable);
-            stack.add(scrollPane);
+                Stack stack = new Stack();
+                stack.add(loadingTable);
+                stack.add(scrollPane);
 
-            mainContent.add(stack).grow();
+                Table centerArea = new Table();
+                centerArea.add(stack).grow().row();
 
-            Events.on(ChatStateChange.class, event -> {
-                var connected = event.connected;
+                buildInputTable(inputTable);
+                centerArea.add(inputTable).growX().bottom();
 
-                if (connectionIndicator != null) {
-                    connectionIndicator.setColor(connected ? Color.green : Color.yellow);
-                }
-            });
+                mainContent.add(centerArea).grow().minWidth(0);
 
-            // Vertical Separator
-            mainContent.image(Tex.whiteui).width(1f * scale).color(Color.darkGray).fillY();
+                // Vertical Separator
+                mainContent.image(Tex.whiteui).width(1f * scale).color(Color.darkGray).fillY();
 
-            // User List Sidebar
-            Table rightSide = new Table();
-            rightSide.top();
-            rightSide.background(Styles.black3);
+                // User List Sidebar
+                Table rightSide = new Table();
+                rightSide.top();
+                rightSide.background(Styles.black3);
 
-            Table titleTable = new Table();
-            if (!isUserListCollapsed) {
-                Label l = titleTable.add("@chat.online-members").style(Styles.defaultLabel).color(Color.gray)
-                        .pad(10 * scale).left()
-                        .minWidth(0).ellipsis(true).growX().get();
-                l.setFontScale(scale);
-            }
-
-            titleTable.button(isUserListCollapsed ? Icon.left : Icon.right, Styles.clearNonei, () -> {
-                isUserListCollapsed = !isUserListCollapsed;
-                setup();
-            }).size(40 * scale).pad(4 * scale).right();
-
-            rightSide.add(titleTable).growX().row();
-
-            if (!isUserListCollapsed) {
                 userListTable = new Table();
                 userListTable.top().left();
-
-                ScrollPane userScrollPane = new ScrollPane(userListTable,
-                        Styles.noBarPane);
+                ScrollPane userScrollPane = new ScrollPane(userListTable, Styles.noBarPane);
                 userScrollPane.setScrollingDisabled(true, false);
 
-                rightSide.add(userScrollPane).grow().row();
-                rightSide.pack();
+                Runnable rebuildRightSide = new Runnable() {
+                    @Override
+                    public void run() {
+                        rightSide.clear();
+                        Table titleTable = new Table();
+                        if (!isUserListCollapsed) {
+                            Label l = titleTable.add("@chat.online-members").style(Styles.defaultLabel)
+                                    .color(Color.gray)
+                                    .pad(10 * scale).left()
+                                    .minWidth(0).ellipsis(true).growX().get();
+                            l.setFontScale(scale);
+                        }
+
+                        titleTable.button(isUserListCollapsed ? Icon.left : Icon.right, Styles.clearNonei, () -> {
+                            isUserListCollapsed = !isUserListCollapsed;
+                            this.run();
+                            Cell<?> cell = mainContent.getCell(rightSide);
+                            if (cell != null) {
+                                cell.width(isUserListCollapsed ? rightWidthCol : rightWidthExp);
+                            }
+                        }).size(40 * scale).pad(4 * scale).right();
+
+                        rightSide.add(titleTable).growX().row();
+
+                        if (!isUserListCollapsed) {
+                            rightSide.add(userScrollPane).grow().row();
+                        }
+                    }
+                };
+                rebuildRightSide.run();
+
+                mainContent.add(rightSide).width(isUserListCollapsed ? rightWidthCol : rightWidthExp).growY();
+
+                container.add(mainContent).grow().minWidth(0).row();
             }
-
-            mainContent.add(rightSide).width(isUserListCollapsed ? 48f * scale : 280f * scale).growY();
-
-            container.add(mainContent).grow().row();
 
             // Fetch users
             Timer.schedule(() -> {
@@ -442,18 +590,18 @@ public class ChatOverlay extends Table {
                 ChatService.getInstance().getChannels(chans -> {
                     channels.clear();
                     channels.addAll(chans);
-                    if (channels.size > 0 && currentChannelId == null) {
-                        switchChannel(channels.get(0).id);
+                    if (channels.size > 0) {
+                        if (currentChannelId == null || !channels.contains(c -> c.id.equals(currentChannelId))) {
+                            switchChannel(channels.get(0).id);
+                        } else {
+                            switchChannel(currentChannelId);
+                        }
                     }
                     rebuildChannelList();
                 }, e -> Log.err("Failed to fetch channels", e));
             } else {
                 rebuildChannelList();
             }
-
-            buildInputTable(inputTable);
-
-            container.add(inputTable).growX().bottom();
 
             // Initial population
             rebuildMessages(messageTable);
@@ -492,6 +640,10 @@ public class ChatOverlay extends Table {
             TextButton btn = new TextButton("# " + channel.name, isSelected ? Styles.togglet : Styles.cleart);
             btn.getLabel().setAlignment(Align.left);
             btn.getLabel().setFontScale(scale);
+            btn.getLabel().setEllipsis(true);
+            if (btn.getLabelCell() != null)
+                btn.getLabelCell().minWidth(0);
+
             if (isSelected) {
                 btn.setChecked(true);
             }
@@ -508,14 +660,19 @@ public class ChatOverlay extends Table {
                 if (!isSelected) {
                     switchChannel(channel.id);
                 }
+                if (Vars.mobile && currentMobileTab != MobileTab.MESSAGES) {
+                    currentMobileTab = MobileTab.MESSAGES;
+                    setup();
+                }
             });
 
-            channelListTable.add(btn).growX().height(40 * scale).pad(2 * scale).row();
+            channelListTable.add(btn).growX().minWidth(0).height(40 * scale).pad(2 * scale).row();
         }
     }
 
     private void switchChannel(String channelId) {
         currentChannelId = channelId;
+        Core.settings.put(CURRENT_CHANNEL_ID_KEY, channelId);
         unreadByChannel.put(channelId, 0);
         updateBadge();
         rebuildChannelList();
@@ -643,7 +800,7 @@ public class ChatOverlay extends Table {
             sendButton.clicked(this::handleSend);
             sendButton.setDisabled(() -> isSending.get());
 
-            inputRow.add(inputField).growX().height(40f * scale).pad(8 * scale).padRight(4 * scale);
+            inputRow.add(inputField).growX().minWidth(0).height(40f * scale).pad(8 * scale).padRight(4 * scale);
 
             inputRow.button(Utils.icons("attach-file.png"), () -> {
                 if (attachContentDialog == null) {
@@ -653,7 +810,7 @@ public class ChatOverlay extends Table {
             }).pad(8 * scale).size(40f * scale);
 
             inputRow.add(sendButton).width(100f * scale).height(40f * scale).pad(8 * scale).padLeft(0);
-            inputTable.add(inputRow).growX();
+            inputTable.add(inputRow).growX().minWidth(0);
         } else {
             inputTable.button("@login", Styles.defaultt, () -> {
                 AuthService.getInstance().login();
@@ -782,6 +939,8 @@ public class ChatOverlay extends Table {
     }
 
     private void rebuildMessages(Table messageTable) {
+        if (messageTable == null)
+            return;
         messageTable.clear();
         messageTable.top().left();
 
@@ -966,7 +1125,7 @@ public class ChatOverlay extends Table {
                 if (expandedMessageId != null && expandedMessageId.equals(msg.id)) {
                     card.row();
                     card.table(actions -> {
-                        actions.left().defaults().height(36 * scale).minWidth(80 * scale).padRight(8 * scale);
+                        actions.left().defaults().height(36 * scale).minWidth(160 * scale).padRight(8 * scale);
 
                         TextButton copyBtn = new TextButton("@copy", Styles.defaultt);
                         copyBtn.clicked(() -> {

--- a/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
+++ b/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
@@ -161,18 +161,16 @@ public class HealthBarVisualizer implements Feature {
             float shieldValue = unit.shield / maxHealth;
             Draw.color(Pal.shield, 0.5f * HealthBarConfig.opacity);
 
-            if (shieldValue > 1) {
-                float shieldW = w * (shieldValue % 1);
+            while (shieldValue > 0) {
+                y += h * 1.5f;
+                float shieldPercent = Math.min(shieldValue, 1f);
+                float shieldW = w * shieldPercent;
                 float shieldCenterX = left + shieldW / 2f;
-                Draw.color(arc.util.Tmp.c1.set(Pal.shield).add(0f, 0f, 0.2f * shieldValue, 0f), 0.75f * HealthBarConfig.opacity);
+                Draw.color(unit.team.color, 0.75f * HealthBarConfig.opacity);
                 Draw.rect(barRegion, shieldCenterX, y, shieldW, h);
-            }
 
-            float shieldPercent = Math.min(shieldValue, 1f);
-            float shieldW = w * shieldPercent;
-            float shieldCenterX = left + shieldW / 2f;
-            Draw.color(unit.team.color, 0.75f * HealthBarConfig.opacity);
-            Draw.rect(barRegion, shieldCenterX, y, shieldW, h);
+                shieldValue -= 1;
+            }
         }
 
         Draw.reset();

--- a/src/mindustrytool/features/display/wavepreview/WavePreviewFeature.java
+++ b/src/mindustrytool/features/display/wavepreview/WavePreviewFeature.java
@@ -16,8 +16,6 @@ import mindustry.Vars;
 import mindustry.content.StatusEffects;
 import mindustry.game.EventType.WorldLoadEvent;
 import mindustry.game.SpawnGroup;
-import mindustry.game.Team;
-import mindustry.gen.Groups;
 import mindustry.gen.Icon;
 import mindustry.gen.Tex;
 import mindustry.type.UnitType;
@@ -27,7 +25,6 @@ import mindustrytool.features.FeatureMetadata;
 import java.util.Optional;
 
 public class WavePreviewFeature extends Table implements Feature {
-    private final ObjectIntMap<UnitType> currentWaveCounts = new ObjectIntMap<>();
     private final ObjectIntMap<UnitType> nextWaveCounts = new ObjectIntMap<>();
 
     private final Interval interval = new Interval();
@@ -48,7 +45,7 @@ public class WavePreviewFeature extends Table implements Feature {
     public void init() {
         name = "wave-preview";
 
-        Events.run(WorldLoadEvent.class, () -> Core.app.post(() -> rebuild()));
+        Events.run(WorldLoadEvent.class, () -> Core.app.post(this::rebuild));
 
         visible(() -> Vars.ui.hudfrag.shown && Vars.state.isGame() && Vars.state.rules.waves);
 
@@ -58,12 +55,11 @@ public class WavePreviewFeature extends Table implements Feature {
             }
 
             if (interval.get(60)) {
-                updateCounts();
-                updateUI();
+                rebuild();
             }
         });
 
-        Core.app.post(() -> rebuild());
+        Core.app.post(this::rebuild);
     }
 
     @Override
@@ -86,7 +82,7 @@ public class WavePreviewFeature extends Table implements Feature {
             waves.row();
             waves.add(this).growX().padTop(10f);
 
-            Core.app.post(() -> rebuild());
+            Core.app.post(this::rebuild);
         }
     }
 
@@ -101,24 +97,12 @@ public class WavePreviewFeature extends Table implements Feature {
     }
 
     private void rebuild() {
-        updateCounts();
-        updateUI();
-    }
-
-    private void updateCounts() {
         if (!Vars.state.isGame()) {
             return;
         }
 
-        currentWaveCounts.clear();
-        Team enemyTeam = Vars.state.rules.waveTeam;
-
-        // Count current enemies
-        Groups.unit.each(u -> u.team == enemyTeam, u -> {
-            currentWaveCounts.put(u.type, currentWaveCounts.get(u.type, 0) + 1);
-        });
-
         nextWaveCounts.clear();
+
         for (SpawnGroup group : Vars.state.rules.spawns) {
             int amount = group.getSpawned(Vars.state.wave - 1);
 
@@ -128,17 +112,12 @@ public class WavePreviewFeature extends Table implements Feature {
                         : Mathf.round(amount * Vars.state.getPlanet().campaignRules.difficulty.enemySpawnMultiplier));
             }
 
-            int spawnedf = amount;
-
-            if (spawnedf > 0) {
-                nextWaveCounts.put(group.type, nextWaveCounts.get(group.type, 0) + spawnedf);
+            if (amount > 0) {
+                nextWaveCounts.put(group.type, nextWaveCounts.get(group.type, 0) + amount);
             }
         }
-    }
 
-    private void updateUI() {
         clear();
-
         top().left();
         background(Tex.pane);
         setColor(1f, 1f, 1f, WavePreviewConfig.opacity());
@@ -150,57 +129,32 @@ public class WavePreviewFeature extends Table implements Feature {
         title.setFontScale(scale);
         row();
 
-        Label waveLabel = add(new Label(() -> "" + Vars.state.wave)).style(Styles.outlineLabel).left().padLeft(4).get();
-        waveLabel.setFontScale(scale);
-        row();
-
-        Table currentWaveTable = new Table();
-        add(currentWaveTable).growX().pad(4).row();
-        buildWaveTable(currentWaveTable, currentWaveCounts);
-
         if (!nextWaveCounts.isEmpty()) {
-            image().color(mindustry.graphics.Pal.gray).height(2).growX().pad(4).row();
-
-            Label nextWaveLabel = add(new Label(() -> "" + (Vars.state.wave + 1))).style(Styles.outlineLabel).left()
+            Label nextWaveLabel = add(new Label(() -> "" + Vars.state.wave)).style(Styles.outlineLabel).left()
                     .padLeft(4).get();
             nextWaveLabel.setFontScale(scale);
             row();
 
             Table nextWaveTable = new Table();
             add(nextWaveTable).growX().pad(4).row();
-            buildWaveTable(nextWaveTable, nextWaveCounts);
+
+            int i = 0;
+            var keys = Seq.with(nextWaveCounts.keys()).sort(u -> u.health);
+
+            for (UnitType type : keys) {
+                int amount = nextWaveCounts.get(type);
+
+                nextWaveTable.image(type.uiIcon).size(16 * 1.5f * scale).padRight(4 * scale);
+                Label l = nextWaveTable.add(String.valueOf(amount)).style(Styles.outlineLabel).padRight(8 * scale)
+                        .get();
+                l.setFontScale(scale);
+
+                if (++i % 3 == 0) {
+                    nextWaveTable.row();
+                }
+            }
         }
 
         pack();
-    }
-
-    private void buildWaveTable(Table table, ObjectIntMap<UnitType> counts) {
-        table.clear();
-        float scale = WavePreviewConfig.scale();
-
-        if (counts.isEmpty()) {
-            Label l = table.add("-").style(Styles.outlineLabel).color(mindustry.graphics.Pal.gray).get();
-            l.setFontScale(scale);
-            return;
-        }
-
-        int i = 0;
-
-        var keys = Seq.with(counts.keys()).sort(u -> u.health);
-
-        for (UnitType type : keys) {
-            int amount = counts.get(type);
-            if (amount <= 0) {
-                continue;
-            }
-
-            table.image(type.uiIcon).size(16 * 1.5f * scale).padRight(4 * scale);
-            Label l = table.add(String.valueOf(amount)).style(Styles.outlineLabel).padRight(8 * scale).get();
-            l.setFontScale(scale);
-
-            if (++i % 3 == 0) {
-                table.row();
-            }
-        }
     }
 }

--- a/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
@@ -118,12 +118,12 @@ public class PlayerConnectRenderer {
 
                 // Mods
                 if (room.getData().getMods().size() > 0) {
-                    var modsLabel = body.add(Iconc.book + " [lightgray]" + Strings.join(", ", room.getData().getMods()))
+                    var modsLabel = body.add(Iconc.book + " [lightgray]" + Strings.join("[white], ", room.getData().getMods()))
                             .left()
                             .padBottom(6);
 
                     if (targetWidth > 0) {
-                        modsLabel.width(contentWidth).ellipsis(true);
+                        modsLabel.width(contentWidth).wrap();
                     } else {
                         modsLabel.wrap().growX();
                     }
@@ -138,7 +138,7 @@ public class PlayerConnectRenderer {
                 Seq<String> unneeded = localMods.select(m -> !serverMods.contains(m));
 
                 if (!missing.isEmpty()) {
-                    var label = body.labelWrap("[scarlet]Missing: " + Strings.join(", ", missing))
+                    var label = body.labelWrap("[scarlet]Missing:[white] " + Strings.join("[white], ", missing))
                             .left()
                             .labelAlign(Align.left)
                             .padBottom(6);

--- a/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnectRenderer.java
@@ -194,12 +194,12 @@ public class PlayerConnectRenderer {
                 body.add().growY().row();
 
                 if (PlayerConnect.isHosting()) {
-                    body.button("You're hosting, can not join another room", Icon.play, () -> {
+                    body.button("You're hosting, close room", Icon.play, () -> {
+                        PlayerConnect.close();
                     })
                             .growX()
                             .height(40f)
-                            .padTop(5)
-                            .disabled(true);
+                            .padTop(5);
                 } else if (matchProtocolVersion) {
                     body.button(Core.bundle.format("join"), Icon.play, () -> {
                         joinRoom(room, unneeded, missing);


### PR DESCRIPTION
Increase the HTTP request timeout from 15 seconds to 60 seconds to accommodate slower network conditions. Wrap the token parsing logic in a try-catch block to prevent unhandled exceptions from crashing the application and ensure all errors are properly propagated to the completion future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Chat channel selection now persists between sessions
  - Mobile chat interface includes dedicated views for channels, messages, and members

* **Improvements**
  - Login timeout increased and token validation/error handling improved
  - Shield visualization rendered as stacked segments using team-based coloring
  - Connection status indicator updates dynamically
  - Chat UI responsiveness and text truncation improved
  - Mod lists and conflict labels improved wrapping/formatting
  - Wave preview simplified; current-wave composition removed

* **Chores**
  - Version updated to v4.47.2-v8
<!-- end of auto-generated comment: release notes by coderabbit.ai -->