### PR TITLE
fix(wavepreview): skip null unit types and zero amounts in preview

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.47.2-v8
+version: v4.47.3-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/display/wavepreview/WavePreviewFeature.java
+++ b/src/mindustrytool/features/display/wavepreview/WavePreviewFeature.java
@@ -104,7 +104,15 @@ public class WavePreviewFeature extends Table implements Feature {
         nextWaveCounts.clear();
 
         for (SpawnGroup group : Vars.state.rules.spawns) {
+            if (group.type == null) {
+                continue;
+            }
+
             int amount = group.getSpawned(Vars.state.wave - 1);
+
+            if (amount == 0) {
+                continue;
+            }
 
             if (Vars.state.isCampaign()) {
                 amount = Math.max(1, group.effect == StatusEffects.boss


### PR DESCRIPTION
Prevents potential NullPointerException when group.type is null. Also avoids displaying units with zero spawn amount in the wave preview table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wave preview to handle invalid spawn groups and skip unnecessary calculations for zero-spawn entries, improving performance.

* **Other**
  * Version bumped to v4.47.3-v8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->