### PR TITLE
feat(savesync): include backup settings file in sync

### DIFF
--- a/src/mindustrytool/features/savesync/SaveSyncFeature.java
+++ b/src/mindustrytool/features/savesync/SaveSyncFeature.java
@@ -46,6 +46,7 @@ public class SaveSyncFeature implements Feature {
     private List<ClientFileDto> listFiles() {
         Seq<Fi> files = new Seq<>();
         files.add(Core.settings.getSettingsFile());
+        files.add(Core.settings.getBackupSettingsFile());
         files.addAll(Vars.customMapDirectory.list());
         files.addAll(Vars.saveDirectory.list());
         // files.addAll(Vars.modDirectory.list());


### PR DESCRIPTION
Add Core.settings.getBackupSettingsFile() to the list of files to be synchronized. This ensures that backup settings are also included when syncing saves, providing a more complete configuration backup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Backup settings file is now included in the file synchronization process, ensuring comprehensive backup coverage during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->