### PR TITLE
fix(quickaccess): separate position settings for portrait/landscape

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.47.3-v8
+version: v4.47.4-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/Main.java
+++ b/src/mindustrytool/Main.java
@@ -242,7 +242,7 @@ public class Main extends Mod {
                                         .withZone(ZoneId.systemDefault());
                                 changelog.append("[lightgray]").append(formatter.format(instant)).append("[] - ");
                             }
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
                             Log.err(e);
                         }
 

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -1,6 +1,8 @@
 package mindustrytool.features.auth;
 
 import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 
@@ -25,6 +27,7 @@ public class AuthService {
     public static final String KEY_ACCESS_TOKEN = "mindustrytool.auth.accessToken";
     public static final String KEY_REFRESH_TOKEN = "mindustrytool.auth.refreshToken";
     public static final String KEY_LOGIN_ID = "mindustrytool.auth.loginId";
+    public static final String KEY_LOGIN_EXPIRY = "mindustrytool.auth.loginExpiry";
 
     public final ReactiveStore<UserSession> sessionStore;
 
@@ -58,6 +61,14 @@ public class AuthService {
         String logindId = Core.settings.getString(KEY_LOGIN_ID);
 
         if (logindId == null) {
+            return;
+        }
+
+        Instant expiry = Instant.parse(Core.settings.getString(KEY_LOGIN_EXPIRY));
+
+        if (expiry.isBefore(Instant.now())) {
+            Core.settings.remove(KEY_LOGIN_ID);
+            Core.settings.remove(KEY_LOGIN_EXPIRY);
             return;
         }
 
@@ -117,6 +128,8 @@ public class AuthService {
                         }).margin(40).growX().wrapLabel(true).fontScale(0.5f);
 
                         Core.settings.put(KEY_LOGIN_ID, loginId);
+                        Core.settings.put(KEY_LOGIN_EXPIRY, Instant.now().plus(Duration.ofMinutes(5)));
+
 
                         // Start polling for token
                         pollLoginToken(loginId).whenComplete((v, e) -> {

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -64,7 +64,7 @@ public class AuthService {
             return;
         }
 
-        Instant expiry = Instant.parse(Core.settings.getString(KEY_LOGIN_EXPIRY));
+        Instant expiry = Instant.ofEpochMilli(Core.settings.getLong(KEY_LOGIN_EXPIRY, 0));
 
         if (expiry.isBefore(Instant.now())) {
             Core.settings.remove(KEY_LOGIN_ID);
@@ -128,8 +128,7 @@ public class AuthService {
                         }).margin(40).growX().wrapLabel(true).fontScale(0.5f);
 
                         Core.settings.put(KEY_LOGIN_ID, loginId);
-                        Core.settings.put(KEY_LOGIN_EXPIRY, Instant.now().plus(Duration.ofMinutes(5)));
-
+                        Core.settings.put(KEY_LOGIN_EXPIRY, Instant.now().plus(Duration.ofMinutes(5)).toEpochMilli());
 
                         // Start polling for token
                         pollLoginToken(loginId).whenComplete((v, e) -> {

--- a/src/mindustrytool/features/autoplay/AutoplayFeature.java
+++ b/src/mindustrytool/features/autoplay/AutoplayFeature.java
@@ -6,6 +6,7 @@ import arc.graphics.g2d.Draw;
 import arc.input.KeyCode;
 import arc.scene.ui.Dialog;
 import arc.struct.Seq;
+import arc.util.Log;
 import arc.util.Timer;
 import mindustry.Vars;
 import mindustry.game.EventType.Trigger;
@@ -78,7 +79,11 @@ public class AutoplayFeature implements Feature {
         Events.run(Trigger.draw, this::draw);
 
         Timer.schedule(() -> {
-            Core.app.post(this::updateTask);
+            try {
+                updateTask();
+            } catch (Exception e) {
+                Log.err(e);
+            }
         }, 0, 0.2f);
 
         Events.run(Trigger.update, () -> {

--- a/src/mindustrytool/features/chat/global/ChatOverlay.java
+++ b/src/mindustrytool/features/chat/global/ChatOverlay.java
@@ -987,7 +987,7 @@ public class ChatOverlay extends Table {
 
                 UserService.findUserById(msg.createdBy).thenAccept(data -> {
                     Core.app.post(() -> {
-                        String timeStr = "";
+                        String timeStr = msg.createdAt;
 
                         if (msg.createdAt != null) {
                             try {
@@ -996,7 +996,7 @@ public class ChatOverlay extends Table {
                                         .withZone(ZoneId.systemDefault())
                                         .format(instant);
 
-                            } catch (Exception err) {
+                            } catch (Throwable err) {
                                 Log.err(err);
                             }
                         }

--- a/src/mindustrytool/features/display/quickaccess/QuickAccessConfig.java
+++ b/src/mindustrytool/features/display/quickaccess/QuickAccessConfig.java
@@ -6,20 +6,24 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class QuickAccessConfig {
+    private static String getAxisKey(String axis) {
+        return "mindustrytool.quickaccess." + axis + (Core.graphics.isPortrait() ? ".portrait" : ".landscape");
+    }
+
     public static float x() {
-        return Core.settings.getFloat("mindustrytool.quickaccess.x", 0);
+        return Core.settings.getFloat(getAxisKey("x"), 0);
     }
 
     public static void x(float value) {
-        Core.settings.put("mindustrytool.quickaccess.x", value);
+        Core.settings.put(getAxisKey("x"), value);
     }
 
     public static float y() {
-        return Core.settings.getFloat("mindustrytool.quickaccess.y", Core.graphics.getHeight() / 2f);
+        return Core.settings.getFloat(getAxisKey("y"), Core.graphics.getHeight() / 2f);
     }
 
     public static void y(float value) {
-        Core.settings.put("mindustrytool.quickaccess.y", value);
+        Core.settings.put(getAxisKey("y"), value);
     }
 
     public static float opacity() {


### PR DESCRIPTION
Modify QuickAccessConfig to use different setting keys based on screen orientation. This prevents position reset when rotating the device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login sessions now include a 5-minute expiry and expired sessions are cleared automatically.

* **Bug Fixes**
  * Quick access panel position is preserved correctly when switching between portrait and landscape.
  * Improved robustness of release checks, chat timestamps, and autoplay startup to reduce silent failures.

* **Chores**
  * Updated version to v4.47.4-v8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->