### PR TITLE
feat(healthbar): disable health bar visualizer by default

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.50.0-v8
+version: v4.50.1-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
+++ b/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
@@ -10,13 +10,11 @@ import arc.scene.ui.Label;
 import arc.scene.ui.Slider;
 import arc.scene.ui.layout.Table;
 import mindustry.Vars;
-import mindustry.game.EventType;
 import mindustry.game.EventType.Trigger;
 import mindustry.gen.Groups;
 import mindustry.gen.Icon;
 import mindustry.gen.Unit;
 import mindustry.graphics.Pal;
-import mindustry.type.UnitType;
 import mindustry.ui.Styles;
 import mindustry.ui.dialogs.BaseDialog;
 import mindustrytool.Utils;
@@ -24,16 +22,12 @@ import mindustrytool.features.Feature;
 import mindustrytool.features.FeatureMetadata;
 
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-
 import static mindustry.Vars.*;
 
 public class HealthBarVisualizer implements Feature {
 
     private static TextureRegion barRegion;
     private BaseDialog dialog;
-
-    private ConcurrentHashMap<UnitType, Float> maxHpMap = new ConcurrentHashMap<>();
 
     @Override
     public FeatureMetadata getMetadata() {
@@ -42,7 +36,7 @@ public class HealthBarVisualizer implements Feature {
                 .description("@feature.health-bar.description")
                 .icon(Utils.icons("healthbar.png"))
                 .order(4)
-                .enabledByDefault(true)
+                .enabledByDefault(false)
                 .quickAccess(true)
                 .build();
     }
@@ -51,7 +45,6 @@ public class HealthBarVisualizer implements Feature {
     public void init() {
         HealthBarConfig.load();
         Events.run(Trigger.draw, this::draw);
-        Events.run(EventType.WorldLoadEndEvent.class, maxHpMap::clear);
     }
 
     @Override
@@ -130,11 +123,6 @@ public class HealthBarVisualizer implements Feature {
 
         float hpPercent = unit.health / unit.maxHealth;
         float maxHealth = unit.maxHealth;
-
-        if (unit.health > maxHealth) {
-            maxHealth = maxHpMap.computeIfAbsent(unit.type, t -> t.health);
-            hpPercent = unit.health / maxHealth;
-        }
 
         float left = x - w / 2f;
 

--- a/src/mindustrytool/features/display/quickaccess/QuickAccessHud.java
+++ b/src/mindustrytool/features/display/quickaccess/QuickAccessHud.java
@@ -19,6 +19,7 @@ import arc.scene.ui.layout.Table;
 import arc.struct.Seq;
 import arc.util.Log;
 import arc.util.Scaling;
+import arc.util.Time;
 import mindustry.Vars;
 import mindustry.game.EventType;
 import mindustry.gen.Icon;
@@ -155,18 +156,37 @@ public class QuickAccessHud extends Table implements Feature {
             }
 
             Button[] btnRef = new Button[1];
+            long[] pressTime = { -1 };
+            boolean[] longPressed = { false };
+
             btnRef[0] = t.button(b -> {
                 b.image(meta.icon())
                         .size(buttonSize * 0.7f)
                         .scaling(Scaling.fit)
                         .update(l -> l.setColor(f.isEnabled() ? Color.white : Pal.gray));
             }, Styles.clearNonei, () -> {
-                f.toggle();
+                if (!longPressed[0]) {
+                    f.toggle();
+                }
             })
                     .size(buttonSize)
                     .margin(margin)
                     .tooltip(meta.name())
                     .get();
+
+            btnRef[0].update(() -> {
+                if (btnRef[0].isPressed()) {
+                    if (pressTime[0] == -1) {
+                        pressTime[0] = Time.millis();
+                        longPressed[0] = false;
+                    } else if (!longPressed[0] && Time.timeSinceMillis(pressTime[0]) >= 300) {
+                        longPressed[0] = true;
+                        f.setting().ifPresent(Dialog::show);
+                    }
+                } else {
+                    pressTime[0] = -1;
+                }
+            });
 
             if (++i % cols == 0)
                 t.row();

--- a/src/mindustrytool/features/smartdrill/SmartDrillFeature.java
+++ b/src/mindustrytool/features/smartdrill/SmartDrillFeature.java
@@ -42,6 +42,7 @@ public class SmartDrillFeature implements Feature {
                 .name("feature.smart-drill.name")
                 .description("feature.smart-drill.description")
                 .icon(Icon.filter)
+                .quickAccess(true)
                 .build();
     }
 


### PR DESCRIPTION
The feature is now disabled by default to avoid cluttering the UI for new users. Removed the dynamic max health calculation for units exceeding their base health, as it was unnecessary complexity. Also cleaned up unused imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health bar percentage calculations for more accurate display
  * Health bar visualization now disabled by default

* **New Features**
  * Quick-access buttons now support short press vs long press actions
  * Smart drill feature added to quick-access

* **Chores**
  * Mod package version updated to v4.50.1-v8
<!-- end of auto-generated comment: release notes by coderabbit.ai -->