### PR TITLE
chore: update Discord invite URL to website redirect link

### DIFF
--- a/src/mindustrytool/Config.java
+++ b/src/mindustrytool/Config.java
@@ -27,7 +27,7 @@ public class Config {
     public static final String UPLOAD_SCHEMATIC_URL = WEB_URL + "/schematics?upload=true";
     public static final String UPLOAD_MAP_URL = WEB_URL + "/maps?upload=true";
 
-    public static final String DISCORD_INVITE_URL = "https://discord.gg/DmjdPCeWPY";
+    public static final String DISCORD_INVITE_URL = "https://mindustry-tool.com/links/mindustry-tool";
 
     public static final List<Sort> sorts = Arrays.asList(//
             new Sort("newest", "time_desc"), //


### PR DESCRIPTION
The old Discord invite link has been replaced with a more maintainable redirect URL that points to the same destination. This allows for easier link management in the future without requiring code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated community link destination to direct users to the Mindustry Tool website portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->