### PR TITLE
feat(chat-translation): add test input field for translation testing

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.50.2-v8
+version: v4.50.3-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/auth/AuthService.java
+++ b/src/mindustrytool/features/auth/AuthService.java
@@ -299,6 +299,13 @@ public class AuthService {
             return refreshFuture;
         }
 
+        if (isTokenNearExpiry(refreshToken)) {
+            Log.info("Refresh token near expiry, removed it");
+            Core.settings.remove(KEY_REFRESH_TOKEN);
+            refreshFuture.complete(false);
+            return refreshFuture;
+        }
+
         Jval json = Jval.newObject();
 
         json.put("refreshToken", refreshToken);

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -8,6 +8,7 @@ import arc.scene.ui.ButtonGroup;
 import arc.scene.ui.Dialog;
 import arc.scene.ui.layout.Table;
 import arc.scene.ui.Label;
+import arc.scene.ui.TextField;
 import arc.scene.ui.TextButton;
 import arc.util.Align;
 import arc.util.Log;
@@ -183,6 +184,8 @@ public class ChatTranslationFeature implements Feature {
         resultLabel.setWrap(true);
         resultLabel.setAlignment(Align.center);
 
+        TextField testInput = new TextField("Hello, Mindustry!");
+
         TextButton testButton = new TextButton(Core.bundle.get("chat-translation.settings.test-button"),
                 Styles.defaultt);
         testButton.clicked(() -> {
@@ -193,7 +196,7 @@ public class ChatTranslationFeature implements Feature {
             testButton.setText(Core.bundle.get("chat-translation.settings.testing"));
             resultLabel.setText(Core.bundle.get("chat-translation.settings.testing-connection"));
 
-            currentProvider.translate("Hello").thenAccept(result -> {
+            currentProvider.translate(testInput.getText()).thenAccept(result -> {
                 Core.app.post(() -> {
                     testButton.setDisabled(false);
                     testButton.setText(Core.bundle.get("chat-translation.settings.test-button"));
@@ -209,6 +212,7 @@ public class ChatTranslationFeature implements Feature {
             });
         });
 
+        root.add(testInput).growX().pad(10).row();
         root.add(testButton).size(250, 50).pad(10)
                 .disabled(b -> currentProvider == noopTranslationProvider
                         || testButton.getText().toString().equals(Core.bundle.get("chat-translation.settings.testing")))

--- a/src/mindustrytool/features/chat/translation/MindustryToolTranslationProvider.java
+++ b/src/mindustrytool/features/chat/translation/MindustryToolTranslationProvider.java
@@ -4,6 +4,7 @@ import arc.Core;
 import arc.util.Http;
 import arc.util.Http.HttpStatusException;
 import mindustry.Vars;
+import mindustry.ui.dialogs.LanguageDialog;
 import mindustrytool.Config;
 import mindustrytool.Utils;
 import arc.scene.ui.layout.Table;
@@ -40,7 +41,7 @@ public class MindustryToolTranslationProvider implements TranslationProvider {
             return future;
         }
 
-        String locale = Vars.ui.language.getLocale().getLanguage();
+        String locale = LanguageDialog.getDisplayName(Vars.ui.language.getLocale());
 
         if (locale.isEmpty()) {
             future.completeExceptionally(new IllegalArgumentException("Invalid locale: " + locale));

--- a/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
+++ b/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
@@ -121,8 +121,11 @@ public class HealthBarVisualizer implements Feature {
         Draw.color(Color.black, 0.6f * HealthBarConfig.opacity);
         Draw.rect(barRegion, x, y, w + 2f, h + 2f);
 
-        float maxHealth = unit.maxHealth;
-        float hpPercent = Math.min(1f, unit.health / maxHealth);
+        float maxHealth = Math.max(unit.maxHealth, 1f);
+        if (Float.isNaN(maxHealth))
+            maxHealth = 1f;
+
+        float hpPercent = Math.max(0f, Math.min(1f, unit.health / maxHealth));
 
         float left = x - w / 2f;
 
@@ -136,6 +139,12 @@ public class HealthBarVisualizer implements Feature {
 
         if (unit.shield > 0) {
             float shieldValue = unit.shield / maxHealth;
+            if (Float.isNaN(shieldValue))
+                shieldValue = 0f;
+
+            // Cap the maximum number of shield bars to prevent OOM
+            shieldValue = Math.min(shieldValue, 20f);
+
             Draw.color(Pal.shield, 0.5f * HealthBarConfig.opacity);
 
             while (shieldValue > 0) {

--- a/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
+++ b/src/mindustrytool/features/display/healthbar/HealthBarVisualizer.java
@@ -121,8 +121,8 @@ public class HealthBarVisualizer implements Feature {
         Draw.color(Color.black, 0.6f * HealthBarConfig.opacity);
         Draw.rect(barRegion, x, y, w + 2f, h + 2f);
 
-        float hpPercent = unit.health / unit.maxHealth;
         float maxHealth = unit.maxHealth;
+        float hpPercent = Math.min(1f, unit.health / maxHealth);
 
         float left = x - w / 2f;
 

--- a/src/mindustrytool/features/playerconnect/NetworkProxy.java
+++ b/src/mindustrytool/features/playerconnect/NetworkProxy.java
@@ -44,7 +44,6 @@ public class NetworkProxy extends Client implements NetListener {
 
     private final IntMap<VirtualConnection> connections = new IntMap<>();
     private final Seq<VirtualConnection> orderedConnections = new Seq<>(false);
-    private final Server server;
     private final NetListener serverDispatcher;
 
     private volatile boolean isShutdown;
@@ -61,13 +60,12 @@ public class NetworkProxy extends Client implements NetListener {
 
         addListener(this);
 
-        NetProvider provider = Reflect.get(Vars.net, "provider");
-
         if (Vars.steam) {
-            provider = Reflect.get(provider, "provider");
+            throw new UnsupportedOperationException("Steam is not supported.");
         }
 
-        server = Reflect.get(provider, "server");
+        NetProvider provider = Reflect.get(Vars.net, "provider");
+        Server server = Reflect.get(provider, "server");
         serverDispatcher = Reflect.get(server, "dispatchListener");
     }
 

--- a/src/mindustrytool/features/playerconnect/PlayerConnect.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnect.java
@@ -155,13 +155,18 @@ public class PlayerConnect {
             Cons<Throwable> onFailed,
             Cons<RoomCloseReason> onDisconnected//
     ) {
-        if (room != null && room.isConnected()) {
-            throw new IllegalStateException("Room is already created, please close it before.");
-        }
+        try {
+            if (room != null && room.isConnected()) {
+                throw new IllegalStateException("Room is already created, please close it before.");
+            }
 
-        if (room == null || roomThread == null || !roomThread.isAlive()) {
-            room = new NetworkProxy();
-            roomThread = Threads.daemon("Proxy", room);
+            if (room == null || roomThread == null || !roomThread.isAlive()) {
+                room = new NetworkProxy();
+                roomThread = Threads.daemon("Proxy", room);
+            }
+        } catch (Exception e) {
+            onFailed.get(e);
+            return;
         }
 
         worker.submit(() -> {


### PR DESCRIPTION
Allow users to input custom text for translation testing instead of using a fixed string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat translation test now uses a custom input field.

* **Bug Fixes**
  * Health bar rendering clamped to valid ranges to prevent over‑/under‑filled bars.
  * Token refresh now detects expiring refresh tokens and aborts renewal early.
  * Connection setup errors are caught and reported instead of escaping.

* **Changes**
  * Translation target selection now aligns with the app’s display language.
  * Steam networking mode is no longer supported.

* **Chores**
  * Version bumped to v4.50.3-v8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->