### PR TITLE
fix: replace empty color tags with [white] for consistent text rendering

### DIFF
--- a/src/mindustrytool/Utils.java
+++ b/src/mindustrytool/Utils.java
@@ -175,22 +175,22 @@ public class Utils {
             return "";
 
         // Links - Run first to avoid matching color tags
-        text = text.replaceAll("\\[(.*?)\\]\\((.*?)\\)", "[sky]$1[]");
+        text = text.replaceAll("\\[(.*?)\\]\\((.*?)\\)", "[sky]$1[white]");
 
         // Headers
-        text = text.replaceAll("(?m)^#{1,6}\\s+(.*)$", "[accent]$1[]");
+        text = text.replaceAll("(?m)^#{1,6}\\s+(.*)$", "[accent]$1[white]");
 
         // List items
         text = text.replaceAll("(?m)^\\s*[-*]\\s+(.*)$", "• $1");
 
         // Bold
-        text = text.replaceAll("\\*\\*(.*?)\\*\\*", "[white]$1[]");
+        text = text.replaceAll("\\*\\*(.*?)\\*\\*", "[white]$1[white]");
 
         // Italic
-        text = text.replaceAll("(?<!\\*)\\*(?!\\*)(.*?)(?<!\\*)\\*(?!\\*)", "[lightgray]$1[]");
+        text = text.replaceAll("(?<!\\*)\\*(?!\\*)(.*?)(?<!\\*)\\*(?!\\*)", "[lightgray]$1[white]");
 
         // Code
-        text = text.replaceAll("`([^`]*)`", "[cyan]$1[]");
+        text = text.replaceAll("`([^`]*)`", "[cyan]$1[white]");
 
         return text;
     }

--- a/src/mindustrytool/features/chat/global/ui/ChannelList.java
+++ b/src/mindustrytool/features/chat/global/ui/ChannelList.java
@@ -66,7 +66,7 @@ public class ChannelList extends Table {
             }
 
             if (hasNewUnreadMessage) {
-                Label indicatorLabel = new Label("[white]\u25CF[]");
+                Label indicatorLabel = new Label("[white]\u25CF[white]");
                 indicatorLabel.setFontScale(scale);
                 indicatorLabel.setAlignment(Align.right);
                 btn.add(indicatorLabel).right().padLeft(4 * scale);

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -101,7 +101,7 @@ public class ChatTranslationFeature implements Feature {
                 .exceptionally(e -> {
                     lastError = e.getMessage();
 
-                    String formated = Strings.format("@\n\n[scarlet]@[]\n\n", message,
+                    String formated = Strings.format("@\n\n[scarlet]@[white]\n\n", message,
                             Core.bundle.get("chat-translation.error.prefix") + e.getMessage());
 
                     cons.get(formated);

--- a/src/mindustrytool/features/playerconnect/NetworkProxy.java
+++ b/src/mindustrytool/features/playerconnect/NetworkProxy.java
@@ -190,15 +190,15 @@ public class NetworkProxy extends Client implements NetListener {
                 long latency = Time.millis() - pingPacket.sendAt;
                 PlayerConnect.ping = (int) latency;
             } else if (object instanceof Packets.MessagePacket messagePacket) {
-                Call.sendMessage("[scarlet][[Server]:[] " + messagePacket.message);
+                Call.sendMessage("[scarlet][[Server]:[white] " + messagePacket.message);
             } else if (object instanceof Packets.Message2Packet message2Packet) {
-                Call.sendMessage("[scarlet][[Server]:[] "
+                Call.sendMessage("[scarlet][[Server]:[white] "
                         + arc.Core.bundle.get("claj.message." + Strings.camelToKebab(message2Packet.message.name())));
             } else if (object instanceof Packets.PopupPacket popupPacket) {
-                Core.app.post(() -> Vars.ui.showText("[scarlet][[Server][] ", popupPacket.message));
+                Core.app.post(() -> Vars.ui.showText("[scarlet][[Server][white] ", popupPacket.message));
             } else if (object instanceof Packets.RoomClosedPacket closedPacket) {
                 closeReason = closedPacket.reason;
-                Core.app.post(() -> Vars.ui.showText("[scarlet][[Server][] ", closedPacket.reason.toString()));
+                Core.app.post(() -> Vars.ui.showText("[scarlet][[Server][white] ", closedPacket.reason.toString()));
             } else if (object instanceof Packets.RoomLinkPacket roomLinkPacket) {
                 // Ignore if the room id is received twice
                 if (roomId != null) {

--- a/src/mindustrytool/services/UpdateService.java
+++ b/src/mindustrytool/services/UpdateService.java
@@ -88,7 +88,7 @@ public class UpdateService {
                                 Instant instant = Instant.parse(publishedAt);
                                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
                                         .withZone(ZoneId.systemDefault());
-                                changelog.append("[lightgray]").append(formatter.format(instant)).append("[] - ");
+                                changelog.append("[lightgray]").append(formatter.format(instant)).append("[white] - ");
                             }
                         } catch (Throwable e) {
                             Log.err(e);


### PR DESCRIPTION
The empty color tag `[]` was causing text after formatted elements to lose color in various UI components. This change replaces all occurrences with `[white]` to maintain consistent text coloring throughout the application, affecting chat indicators, error messages, markdown rendering, and server notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined text color formatting consistency across chat messages, markdown rendering, error notifications, server message indicators, and update dialogs for improved visual coherence throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->