### PR TITLE
refactor(chat): use Stack layout for message actions overlay

### DIFF
--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -144,6 +144,7 @@ team-resources.show-units = Show Units
 team-resources.show-power = Show Power
 team-resources.show-stored-power = Show Stored Power
 team-resources.hide-background = Hide Background
+team-resources.always-show-flow-rate = Always Show Flow Rate
 
 health-bar.settings.title = Health Bar Settings
 reset = Reset

--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.53.2-v8
+version: v4.53.3-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/Utils.java
+++ b/src/mindustrytool/Utils.java
@@ -268,4 +268,14 @@ public class Utils {
             }
         });
     }
+
+
+    public static boolean hasField(Class<?> clazz, String fieldName) {
+        try {
+            clazz.getDeclaredField(fieldName);
+            return true;
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
+    }
 }

--- a/src/mindustrytool/features/chat/global/ChatService.java
+++ b/src/mindustrytool/features/chat/global/ChatService.java
@@ -73,6 +73,7 @@ public class ChatService {
     }
 
     public void disconnectStream() {
+        Log.info("Disconnecting chat stream...");
         streamClient.disconnect();
         Log.info("Chat stream disconnected.");
     }

--- a/src/mindustrytool/features/chat/global/ChatStateManager.java
+++ b/src/mindustrytool/features/chat/global/ChatStateManager.java
@@ -78,7 +78,7 @@ public class ChatStateManager {
     private void handleStateChange(StateChangeEvent event) {
         if (event.to == State.menu && !Core.graphics.isHidden()) {
             updateState(MENU_STATE);
-        } else if (event.to == State.playing) {
+        } else if (event.to == State.playing && !stateBeforePause.isEmpty()) {
             updateState(stateBeforePause);
         }
     }

--- a/src/mindustrytool/features/chat/global/ChatStateManager.java
+++ b/src/mindustrytool/features/chat/global/ChatStateManager.java
@@ -32,17 +32,22 @@ public class ChatStateManager {
     private final Runnable refreshCurrentChannelUsers;
     private final AtomicBoolean isSyncing = new AtomicBoolean(false);
 
+    private String stateBeforePause = "";
     private String currentState = "";
     private String syncedState = "";
 
     public void init() {
         registerStateListeners();
-        Timer.schedule(this::refreshCurrentState, 60,60);
+        Timer.schedule(this::refreshCurrentState, 60, 60);
     }
 
     public void updateState(String state) {
         if (state == null || state.isEmpty()) {
             return;
+        }
+
+        if (state.equals(MENU_STATE)) {
+            stateBeforePause = currentState;
         }
 
         currentState = state;
@@ -73,6 +78,8 @@ public class ChatStateManager {
     private void handleStateChange(StateChangeEvent event) {
         if (event.to == State.menu && !Core.graphics.isHidden()) {
             updateState(MENU_STATE);
+        } else if (event.to == State.playing) {
+            updateState(stateBeforePause);
         }
     }
 

--- a/src/mindustrytool/features/chat/global/ChatStreamClient.java
+++ b/src/mindustrytool/features/chat/global/ChatStreamClient.java
@@ -61,13 +61,15 @@ public class ChatStreamClient {
 
     public synchronized void disconnect() {
         isStreaming.set(false);
+        Log.info("Update connection");
         updateConnection(false);
 
+        Log.info("Close connecton");
         if (currentConnection != null) {
-            currentConnection.disconnect();
             currentConnection = null;
         }
 
+        Log.info("Stop thread.");
         if (streamThread != null) {
             streamThread.interrupt();
             streamThread = null;

--- a/src/mindustrytool/features/chat/global/ui/MessageList.java
+++ b/src/mindustrytool/features/chat/global/ui/MessageList.java
@@ -9,6 +9,7 @@ import arc.scene.ui.Label;
 import arc.scene.ui.ScrollPane;
 import arc.scene.ui.TextButton;
 import arc.scene.ui.layout.Scl;
+import arc.scene.ui.layout.Stack;
 import arc.scene.ui.layout.Table;
 import arc.struct.Seq;
 import arc.util.Align;
@@ -95,7 +96,7 @@ public class MessageList extends Table {
                 .get()
                 .setFontScale(scale);
 
-        arc.scene.ui.layout.Stack stack = new arc.scene.ui.layout.Stack();
+        Stack stack = new Stack();
         stack.add(loadingTable);
         stack.add(scrollPane);
 
@@ -177,104 +178,116 @@ public class MessageList extends Table {
             }).width(48 * scale).top().padLeft(8 * scale).padRight(8 * scale).padTop(isSameUser ? 0 : 8 * scale)
                     .padBottom(isNextSameUser ? 0 : 8 * scale);
 
-            entry.table(card -> {
-                card.top().left();
+            entry.table(cardContainer -> {
+                cardContainer.top().left();
 
-                if (!isSameUser) {
-                    Label label = new Label("...");
-                    label.setStyle(Styles.defaultLabel);
-                    label.setFontScale(scale);
+                Stack cardStack = new Stack();
 
-                    UserService.findUserById(msg.createdBy).thenAccept(data -> {
-                        Core.app.post(() -> {
-                            String timeStr = msg.createdAt;
-                            if (msg.createdAt != null) {
-                                try {
-                                    Instant instant = Instant.parse(msg.createdAt);
-                                    timeStr = DateTimeFormatter.ofPattern("HH:mm")
-                                            .withZone(ZoneId.systemDefault())
-                                            .format(instant);
-                                } catch (Throwable err) {
-                                    Log.err(err);
+                cardStack.add(new Table(card -> {
+                    card.top().left();
+
+                    if (!isSameUser) {
+                        Label label = new Label("...");
+                        label.setStyle(Styles.defaultLabel);
+                        label.setFontScale(scale);
+
+                        UserService.findUserById(msg.createdBy).thenAccept(data -> {
+                            Core.app.post(() -> {
+                                String timeStr = msg.createdAt;
+                                if (msg.createdAt != null) {
+                                    try {
+                                        Instant instant = Instant.parse(msg.createdAt);
+                                        timeStr = DateTimeFormatter.ofPattern("HH:mm")
+                                                .withZone(ZoneId.systemDefault())
+                                                .format(instant);
+                                    } catch (Throwable err) {
+                                        Log.err(err);
+                                    }
                                 }
-                            }
 
-                            Color color = data.getHighestRole()
-                                    .map(r -> {
-                                        try {
-                                            return Color.valueOf(r.getColor());
-                                        } catch (Exception err) {
-                                            return Color.white;
-                                        }
-                                    })
-                                    .orElse(Color.white);
+                                Color color = data.getHighestRole()
+                                        .map(r -> {
+                                            try {
+                                                return Color.valueOf(r.getColor());
+                                            } catch (Exception err) {
+                                                return Color.white;
+                                            }
+                                        })
+                                        .orElse(Color.white);
 
-                            label.setText("[#" + color.toString() + "]" + data.getName() + "[white]"
-                                    + (timeStr.isEmpty() ? "" : " [gray]" + timeStr));
+                                label.setText("[#" + color.toString() + "]" + data.getName() + "[white]"
+                                        + (timeStr.isEmpty() ? "" : " [gray]" + timeStr));
+                            });
                         });
+
+                        card.add(label).left().row();
+                    }
+
+                    if (msg.replyTo != null && !msg.replyTo.isEmpty()) {
+                        ChatMessage repliedMsg = channelMsgs.find(m -> m.id.equals(msg.replyTo));
+                        if (repliedMsg != null) {
+                            card.table(replyTable -> {
+                                replyTable.center().left();
+                                replyTable.image(Icon.rightSmall).size(16 * scale).padRight(4 * scale)
+                                        .color(Color.gray);
+
+                                Label replyContent = new Label(repliedMsg.content.replace('\n', ' '));
+                                replyContent.setFontScale(scale);
+                                replyContent.setColor(Color.gray);
+                                replyContent.setEllipsis(true);
+                                replyTable.add(replyContent).minWidth(0).maxWidth(200 * scale);
+                            }).growX().padTop(isSameUser ? 2 * scale : 0).padBottom(0).row();
+                        }
+                    }
+
+                    card.table(c -> renderContent(c, msg.content, scale)).top().left().growX()
+                            .padTop(isSameUser && (msg.replyTo == null || msg.replyTo.isEmpty()) ? 2 * scale : 0);
+
+                    card.clicked(() -> {
+                        if (expandedMessageId != null && expandedMessageId.equals(msg.id)) {
+                            expandedMessageId = null;
+                        } else {
+                            expandedMessageId = msg.id;
+                        }
+                        rebuild();
                     });
+                }));
 
-                    card.add(label).left().row();
-                }
-
-                if (msg.replyTo != null && !msg.replyTo.isEmpty()) {
-                    ChatMessage repliedMsg = channelMsgs.find(m -> m.id.equals(msg.replyTo));
-                    if (repliedMsg != null) {
-                        card.table(replyTable -> {
-                            replyTable.center().left();
-                            replyTable.image(Icon.rightSmall).size(16 * scale).padRight(4 * scale).color(Color.gray);
-
-                            Label replyContent = new Label(repliedMsg.content.replace('\n', ' '));
-                            replyContent.setFontScale(scale);
-                            replyContent.setColor(Color.gray);
-                            replyContent.setEllipsis(true);
-                            replyTable.add(replyContent).minWidth(0).maxWidth(200 * scale);
-                        }).growX().padTop(isSameUser ? 2 * scale : 0).padBottom(0).row();
-                    }
-                }
-
-                card.table(c -> renderContent(c, msg.content, scale)).top().left().growX()
-                        .padTop(isSameUser && (msg.replyTo == null || msg.replyTo.isEmpty()) ? 2 * scale : 0);
-
-                card.clicked(() -> {
+                Table overlayTable = new Table(overlay -> {
                     if (expandedMessageId != null && expandedMessageId.equals(msg.id)) {
-                        expandedMessageId = null;
-                    } else {
-                        expandedMessageId = msg.id;
-                    }
-                    rebuild();
-                });
+                        overlay.top().left();
+                        overlay.table(actions -> {
+                            actions.left().defaults().height(36 * scale).minWidth(160 * scale).padRight(8 * scale);
 
-                if (expandedMessageId != null && expandedMessageId.equals(msg.id)) {
-                    card.row();
-                    card.table(actions -> {
-                        actions.left().defaults().height(36 * scale).minWidth(160 * scale).padRight(8 * scale);
+                            TextButton copyBtn = new TextButton("@copy", Styles.defaultt);
+                            copyBtn.clicked(() -> {
+                                try {
+                                    Core.app.setClipboardText(msg.content);
+                                    Vars.ui.showInfoFade("@copied");
+                                    expandedMessageId = null;
+                                    rebuild();
+                                } catch (Exception e) {
+                                    Vars.ui.showInfoFade(e.getMessage());
+                                }
+                            });
+                            copyBtn.getLabel().setFontScale(scale * 0.8f);
+                            actions.add(copyBtn);
 
-                        TextButton copyBtn = new TextButton("@copy", Styles.defaultt);
-                        copyBtn.clicked(() -> {
-                            try {
-                                Core.app.setClipboardText(msg.content);
-                                Vars.ui.showInfoFade("@copied");
+                            TextButton replyBtn = new TextButton("@chat.reply", Styles.defaultt);
+                            replyBtn.clicked(() -> {
+                                chatInput.setReplyingTo(msg.id);
                                 expandedMessageId = null;
                                 rebuild();
-                            } catch (Exception e) {
-                                Vars.ui.showInfoFade(e.getMessage());
-                            }
-                        });
-                        copyBtn.getLabel().setFontScale(scale * 0.8f);
-                        actions.add(copyBtn);
+                            });
+                            replyBtn.getLabel().setFontScale(scale * 0.8f);
+                            actions.add(replyBtn);
+                        }).left().padTop(4 * scale);
+                    }
+                });
+                cardStack.add(overlayTable);
+                overlayTable.toFront();
 
-                        TextButton replyBtn = new TextButton("@chat.reply", Styles.defaultt);
-                        replyBtn.clicked(() -> {
-                            chatInput.setReplyingTo(msg.id);
-                            expandedMessageId = null;
-                            rebuild();
-                        });
-                        replyBtn.getLabel().setFontScale(scale * 0.8f);
-                        actions.add(replyBtn);
-
-                    }).growX().padTop(4 * scale);
-                }
+                cardContainer.add(cardStack).growX();
             }).growX().padLeft(8 * scale).padRight(8 * scale).padTop(isSameUser ? 0 : 8 * scale)
                     .padBottom(isNextSameUser ? 0 : 8 * scale).top();
 

--- a/src/mindustrytool/features/display/teamresource/TeamResourceConfig.java
+++ b/src/mindustrytool/features/display/teamresource/TeamResourceConfig.java
@@ -85,4 +85,12 @@ public class TeamResourceConfig {
     public static void hideBackground(boolean value) {
         Core.settings.put(PREFIX + "hide-background", value);
     }
+
+    public static boolean alwaysShowFlowRate() {
+        return Core.settings.getBool(PREFIX + "always-show-flow-rate", false);
+    }
+
+    public static void alwaysShowFlowRate(boolean value) {
+        Core.settings.put(PREFIX + "always-show-flow-rate", value);
+    }
 }

--- a/src/mindustrytool/features/display/teamresource/TeamResourceFeature.java
+++ b/src/mindustrytool/features/display/teamresource/TeamResourceFeature.java
@@ -416,13 +416,12 @@ public class TeamResourceFeature extends Table implements Feature {
         int amount = coreItems.get(item);
         int rate = rateDisplay.get(item);
 
+        if (TeamResourceConfig.alwaysShowFlowRate()) {
+            return formatAmountWithRate(amount, rate);
+        }
+
         if (viewingStats) {
-            if (rate == 0)
-                return "[gray]0/s";
-
-            String prefix = rate > 0 ? "[lime]+" : "[scarlet]";
-
-            return prefix + rate + "[gray]/s";
+            return formatRate(rate);
         }
 
         String color = "[white]";
@@ -433,6 +432,26 @@ public class TeamResourceFeature extends Table implements Feature {
         }
 
         return color + UI.formatAmount(amount);
+    }
+
+    private String formatAmountWithRate(int amount, int rate) {
+        String color = "[white]";
+        if (rate < 0) {
+            color = "[scarlet]";
+        } else if (rate > 0) {
+            color = "[lime]";
+        }
+
+        return color + UI.formatAmount(amount) + " [gray](" + formatRate(rate) + "[gray])";
+    }
+
+    private String formatRate(int rate) {
+        if (rate == 0) {
+            return "0/s";
+        }
+
+        String prefix = rate > 0 ? "[lime]+" : "[scarlet]";
+        return prefix + rate + "[gray]/s";
     }
 
     public class TeamResourceSettingsDialog extends BaseDialog {
@@ -451,6 +470,7 @@ public class TeamResourceFeature extends Table implements Feature {
                 TeamResourceConfig.showPower(true);
                 TeamResourceConfig.showStoredPower(false);
                 TeamResourceConfig.hideBackground(false);
+                TeamResourceConfig.alwaysShowFlowRate(false);
 
                 rebuild();
                 hide();
@@ -546,6 +566,11 @@ public class TeamResourceFeature extends Table implements Feature {
 
             cont.check("@team-resources.hide-background", TeamResourceConfig.hideBackground(), b -> {
                 TeamResourceConfig.hideBackground(b);
+                rebuild();
+            }).left().padTop(4).row();
+
+            cont.check("@team-resources.always-show-flow-rate", TeamResourceConfig.alwaysShowFlowRate(), b -> {
+                TeamResourceConfig.alwaysShowFlowRate(b);
                 rebuild();
             }).left().padTop(4).row();
         }

--- a/src/mindustrytool/features/playerconnect/NetworkProxy.java
+++ b/src/mindustrytool/features/playerconnect/NetworkProxy.java
@@ -60,11 +60,12 @@ public class NetworkProxy extends Client implements NetListener {
 
         addListener(this);
 
+        NetProvider provider = Reflect.get(Vars.net, "provider");
+
         if (Vars.steam) {
-            throw new UnsupportedOperationException("Steam is not supported.");
+            provider = Reflect.get(provider, "provider");
         }
 
-        NetProvider provider = Reflect.get(Vars.net, "provider");
         Server server = Reflect.get(provider, "server");
         serverDispatcher = Reflect.get(server, "dispatchListener");
     }

--- a/src/mindustrytool/features/playerconnect/PlayerConnect.java
+++ b/src/mindustrytool/features/playerconnect/PlayerConnect.java
@@ -186,6 +186,7 @@ public class PlayerConnect {
     public static void close() {
         if (room != null) {
             room.closeRoom();
+            Log.info("Close room on exit");
         }
     }
 

--- a/src/mindustrytool/features/settings/FeatureSettingDialog.java
+++ b/src/mindustrytool/features/settings/FeatureSettingDialog.java
@@ -252,7 +252,7 @@ public class FeatureSettingDialog extends BaseDialog {
         paneTable.clear();
         paneTable.top().left();
 
-        int cols = Math.max(1, (int) (arc.Core.graphics.getWidth() / Scl.scl() * 0.85f / 340f));
+        int cols = Math.max(1, (int) (arc.Core.graphics.getWidth() / Scl.scl() * 0.85f / Scl.scl(340f)));
         float cardWidth = ((float) arc.Core.graphics.getWidth() / Scl.scl() * 0.85f) / cols;
 
         paneTable.row();

--- a/src/mindustrytool/services/PlayerConnectService.java
+++ b/src/mindustrytool/services/PlayerConnectService.java
@@ -13,6 +13,8 @@ import mindustrytool.features.playerconnect.PlayerConnectProvider;
 
 public class PlayerConnectService {
 
+    private CompletableFuture<Seq<PlayerConnectRoom>> roomFuture;
+
     private PlayerConnectService() {
     }
 
@@ -28,22 +30,31 @@ public class PlayerConnectService {
     private final ConcurrentHashMap<String, PlayerConnectRoom> roomCache = new ConcurrentHashMap<>();
 
     public CompletableFuture<Seq<PlayerConnectRoom>> findPlayerConnectRooms(String q) {
-        CompletableFuture<Seq<PlayerConnectRoom>> future = new CompletableFuture<>();
+        if (roomFuture != null) {
+            return roomFuture;
+        }
+
+        roomFuture = new CompletableFuture<>();
 
         Http.get(Config.API_v4_URL + "player-connect/rooms?q=" + q)
                 .timeout(60000)
-                .error(future::completeExceptionally)
+                .error(error -> {
+                    roomFuture.completeExceptionally(error);
+                    roomFuture = null;
+                })
                 .submit(response -> {
                     try {
                         String data = response.getResultAsString();
                         Seq<PlayerConnectRoom> rooms = Seq.with(Utils.fromJsonArray(PlayerConnectRoom.class, data));
-                        future.complete(rooms);
+                        roomFuture.complete(rooms);
                     } catch (Exception e) {
-                        future.completeExceptionally(e);
+                        roomFuture.completeExceptionally(e);
+                    } finally {
+                        roomFuture = null;
                     }
                 });
 
-        return future;
+        return roomFuture;
     }
 
     public CompletableFuture<Seq<PlayerConnectProvider>> findPlayerConnectProvider() {

--- a/src/mindustrytool/services/PlayerConnectService.java
+++ b/src/mindustrytool/services/PlayerConnectService.java
@@ -29,7 +29,7 @@ public class PlayerConnectService {
 
     private final ConcurrentHashMap<String, PlayerConnectRoom> roomCache = new ConcurrentHashMap<>();
 
-    public CompletableFuture<Seq<PlayerConnectRoom>> findPlayerConnectRooms(String q) {
+    public synchronized CompletableFuture<Seq<PlayerConnectRoom>> findPlayerConnectRooms(String q) {
         if (roomFuture != null) {
             return roomFuture;
         }


### PR DESCRIPTION
Refactor the message card layout to use a Stack container for the actions overlay instead of conditionally adding a row. This separates the overlay from the main content table, improving layout structure and making the click-to-expand behavior more maintainable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Team Resources setting "Always Show Flow Rate" to always display per-item flow rates.

* **Improvements**
  * Chat state is preserved when opening the menu and restored on return.
  * Player connection room searches are optimized to avoid redundant queries.
  * Settings layout now adapts column sizing better across UI scales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->