### PR TITLE
fix(time): conditionally show time control HUD

### DIFF
--- a/mod.hjson
+++ b/mod.hjson
@@ -53,7 +53,7 @@ description:
   [#FAA31B[]]  Reddit: [white[]]r/MindustryTool[[]]
   [#EF4444[]]  YouTube: [white[]]Mindustry Tool[[]]
   '''
-version: v4.55.0-v8
+version: v4.55.1-v8
 
 minGameVersion: 154
 

--- a/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationConfig.java
@@ -14,14 +14,6 @@ public class ChatTranslationConfig {
     public static final String DEEPL_API_KEY = "mindustrytool.chat-translation.deepl.api-key";
     public static final String DEEPL_TIMEOUT = "mindustrytool.chat-translation.deepl.timeout";
 
-    public static boolean isShowOriginal() {
-        return Core.settings.getBool(SHOW_ORIGINAL, true);
-    }
-
-    public static void setShowOriginal(boolean showOriginal) {
-        Core.settings.put(SHOW_ORIGINAL, showOriginal);
-    }
-
     public static String getProviderId() {
         return Core.settings.getString(PROVIDER, "noop");
     }

--- a/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationFeature.java
@@ -78,15 +78,6 @@ public class ChatTranslationFeature implements Feature {
         }
 
         currentProvider.translate(Strings.stripColors(message))
-                .thenApply(translated -> {
-                    if (ChatTranslationConfig.isShowOriginal()) {
-                        String formated = Strings.format("[white]@ [gray](@)", message, translated);
-
-                        return formated;
-                    }
-
-                    return translated;
-                })
                 .thenAccept(formated -> cons.get(formated))
                 .exceptionally(e -> {
                     lastError = e.getMessage();

--- a/src/mindustrytool/features/chat/translation/ChatTranslationSettingsDialog.java
+++ b/src/mindustrytool/features/chat/translation/ChatTranslationSettingsDialog.java
@@ -20,11 +20,6 @@ public class ChatTranslationSettingsDialog extends BaseDialog {
 
         Table root = new Table();
         root.top().left().defaults().top().left().padBottom(5);
-
-        root.check("@chat-translation.settings.show-original", ChatTranslationConfig.isShowOriginal(), val -> {
-            ChatTranslationConfig.setShowOriginal(val);
-        }).row();
-
         root.image().height(4).color(Color.gray).fillX().pad(10).row();
 
         root.add("@chat-translation.settings.providers").style(Styles.outlineLabel).padBottom(5).row();

--- a/src/mindustrytool/features/time/TimeControlFeature.java
+++ b/src/mindustrytool/features/time/TimeControlFeature.java
@@ -48,9 +48,9 @@ public class TimeControlFeature extends Table implements Feature {
         touchable = Touchable.childrenOnly;
 
         setPosition(TimeControlConfig.x(), TimeControlConfig.y());
+        visible(() -> Vars.ui.hudfrag.shown && !Vars.net.client());
 
         Events.on(EventType.ResizeEvent.class, e -> rebuild());
-        visible(() -> !Vars.net.client());
 
         Core.app.post(this::rebuild);
     }
@@ -153,7 +153,6 @@ public class TimeControlFeature extends Table implements Feature {
             remove();
 
             name = "time-control-hud";
-            visible(() -> Vars.ui.hudfrag.shown && Vars.state.isGame());
 
             Core.app.post(() -> Vars.ui.hudGroup.addChild(this));
         }

--- a/src/mindustrytool/features/time/TimeControlFeature.java
+++ b/src/mindustrytool/features/time/TimeControlFeature.java
@@ -48,7 +48,7 @@ public class TimeControlFeature extends Table implements Feature {
         touchable = Touchable.childrenOnly;
 
         setPosition(TimeControlConfig.x(), TimeControlConfig.y());
-        visible(() -> Vars.ui.hudfrag.shown && !Vars.net.client());
+        visible(() -> Vars.ui.hudfrag.shown && isEnabled() && !Vars.net.client());
 
         Events.on(EventType.ResizeEvent.class, e -> rebuild());
 


### PR DESCRIPTION
The HUD was incorrectly visible in non-game states. Now only shows when the game HUD is visible and not in multiplayer client mode. Also fixes positioning logic to rebuild on resize events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted time control widget visibility to display only when the HUD fragment is active and the feature is enabled.

* **Chores**
  * Removed "Show Original" text option from chat translation settings.
  * Incremented patch version to v4.55.1-v8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->