### PR TITLE
fix(playerconnect): adjust create room dialog max width for scaling

### DIFF
--- a/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
+++ b/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
@@ -45,7 +45,7 @@ public class CreateRoomDialog extends BaseDialog {
         addCloseButton();
 
         mainTable = new Table();
-        cont.add(mainTable).growX().maxWidth(Math.min(Core.graphics.getWidth(), 1200f) / Scl.scl());
+        cont.add(mainTable).growX().maxWidth(Math.min(Core.graphics.getWidth(), 1200f) / Scl.scl() * 0.9f);
 
         shown(() -> {
             if (!PlayerConnect.isRoomClosed()) {

--- a/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
+++ b/src/mindustrytool/features/playerconnect/CreateRoomDialog.java
@@ -8,6 +8,7 @@ import arc.graphics.g2d.Draw;
 import arc.scene.ui.Button;
 import arc.scene.ui.TextButton;
 import arc.scene.ui.layout.Cell;
+import arc.scene.ui.layout.Scl;
 import arc.scene.ui.layout.Stack;
 import arc.scene.ui.layout.Table;
 import arc.struct.Seq;
@@ -44,7 +45,7 @@ public class CreateRoomDialog extends BaseDialog {
         addCloseButton();
 
         mainTable = new Table();
-        cont.add(mainTable).growX().maxWidth(1200f);
+        cont.add(mainTable).growX().maxWidth(Math.min(Core.graphics.getWidth(), 1200f) / Scl.scl());
 
         shown(() -> {
             if (!PlayerConnect.isRoomClosed()) {


### PR DESCRIPTION
Ensure the dialog width respects screen scaling and does not exceed the screen width. Use Scl.scl() to properly scale the maximum width limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Create Room Dialog now dynamically adjusts its width based on screen size and UI scaling for improved layout responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->